### PR TITLE
Driver for ERASynth

### DIFF
--- a/qkit/drivers/ERASynth.py
+++ b/qkit/drivers/ERASynth.py
@@ -25,10 +25,12 @@ import warnings
 from time import sleep
 from enum import Enum
 
+
 class ReferenceSource(Enum):
     EXTERNAL = 0
     OCXO = 1
     TCXO = 2
+
 
 def _reference_class_conversion(reference):
     reference = {
@@ -41,6 +43,7 @@ def _reference_class_conversion(reference):
                             'EXTERNAL', 'OCXO', 'TCXO'""")
     return reference
 
+
 class ERASynth(Instrument):
     '''
     This is the python driver for the ERASynth+ microwave source
@@ -49,7 +52,7 @@ class ERASynth(Instrument):
         <name> = instruments.create('<name>', address='<TCP/IP>')
     '''
 
-    def __init__(self, name, address, reference='external', model = 'ERASynth'):
+    def __init__(self, name, address, reference='external', model='ERASynth'):
         '''
         Initializes the ZeroRPC Client to communicate with according Server (RPi).
         Input:
@@ -70,16 +73,16 @@ class ERASynth(Instrument):
 
         # Implement parameters
         self.add_parameter('frequency', type=float,
-            flags=Instrument.FLAG_GETSET,
-            minval=250e3, maxval=15e9,
-            units='Hz')
+                           flags=Instrument.FLAG_GETSET,
+                           minval=250e3, maxval=15e9,
+                           units='Hz')
         self.add_parameter('power', type=float,
-            flags=Instrument.FLAG_GETSET,
-            minval=-60, maxval=20,   #15 dBm Typ, up to 20 depending on F
-            units='dBm')
+                           flags=Instrument.FLAG_GETSET,
+                           minval=-60, maxval=20,  # 15 dBm Typ, up to 20 depending on F
+                           units='dBm')
         self.add_parameter('status', type=bool,
-            flags=Instrument.FLAG_GETSET)
-        
+                           flags=Instrument.FLAG_GETSET)
+
         # Implement functions
         self.get_all(True)
 
@@ -93,7 +96,8 @@ class ERASynth(Instrument):
                 if self.get_diag()["lock_xtal"] == "1":
                     lockcount += 1
             if lockcount == 0:
-                warnings.warn("No Lock possible. Check your reference. Defaulted to OCXO.")
+                warnings.warn(
+                    "No Lock possible. Check your reference. Defaulted to OCXO.")
                 self.set_reference(ReferenceSource.OCXO)
             elif lockcount < 10:
                 warnings.warn("""External reference unstable. Check for sufficient 
@@ -174,7 +178,7 @@ class ERASynth(Instrument):
         self.get_all(query)
         return self._reference
 
-    #Communication with device
+    # Communication with device
     def do_get_frequency(self, query=True):
         '''
         Get frequency of device
@@ -185,7 +189,7 @@ class ERASynth(Instrument):
         '''
         self.get_all(query)
         return self._frequency
-        
+
     def do_set_frequency(self, frequency):
         '''
         Set frequency of device
@@ -209,7 +213,7 @@ class ERASynth(Instrument):
         self.get_all(query)
         return self._power
 
-    def do_set_power(self,power = None):
+    def do_set_power(self, power=None):
         '''
         Typ. Max. Output 15 dB, Absolute Max. 20 dBm
         Input:
@@ -232,7 +236,7 @@ class ERASynth(Instrument):
         self.get_all(query)
         return self._status
 
-    def do_set_status(self,status):
+    def do_set_status(self, status):
         '''
         Set status of output (Bool)
         Input:
@@ -246,7 +250,7 @@ class ERASynth(Instrument):
         else:
             self._rpc.disableout()
 
-    #shortcuts
+    # shortcuts
     def off(self):
         '''Turn RF Output Off'''
         self.set_status(False)

--- a/qkit/drivers/ERASynth.py
+++ b/qkit/drivers/ERASynth.py
@@ -1,0 +1,256 @@
+# Qkit driver for microwave source ERASynth
+# filename: ERASynth.py
+# Robert Gartmann <uwdqt@student.kit.edu>, 2019
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+from qkit.core.instrument_base import Instrument
+import zerorpc
+import types
+import logging
+import json
+import warnings
+from time import sleep
+from enum import Enum
+
+class ReferenceSource(Enum):
+    EXTERNAL = 0
+    OCXO = 1
+    TCXO = 2
+
+def _reference_class_conversion(reference):
+    reference = {
+        'EXTERNAL': ReferenceSource.EXTERNAL,
+        'OCXO': ReferenceSource.OCXO,
+        'TCXO': ReferenceSource.TCXO
+    }.get(reference.upper(), None)
+    if reference is None:
+        raise ValueError("""Invalid reference. Valid options are (case insensitive): 
+                            'EXTERNAL', 'OCXO', 'TCXO'""")
+    return reference
+
+class ERASynth(Instrument):
+    '''
+    This is the python driver for the ERASynth+ microwave source
+    Usage:
+        Initialise with
+        <name> = instruments.create('<name>', address='<TCP/IP>')
+    '''
+
+    def __init__(self, name, address, reference='external', model = 'ERASynth'):
+        '''
+        Initializes the ZeroRPC Client to communicate with according Server (RPi).
+        Input:
+            name (string)    : name of the instrument
+            address (string) : TCPIP Address including port e.g. "141.52.65.185:4242"
+            reference (string): Choose 10MHz Reference(EXTERNAL, OCXO, TCXO).
+                External will be checked for lock; Default to Oven if not present.
+        '''
+
+        logging.info(__name__ + ' : Initializing instrument')
+        Instrument.__init__(self, name)
+        self._address = "tcp://" + address
+        self._model = model
+        self._statusdict = {}
+        self._reference = reference
+        self._rpc = zerorpc.Client()
+        self._rpc.connect(self._address)
+
+        # Implement parameters
+        self.add_parameter('frequency', type=float,
+            flags=Instrument.FLAG_GETSET,
+            minval=250e3, maxval=15e9,
+            units='Hz')
+        self.add_parameter('power', type=float,
+            flags=Instrument.FLAG_GETSET,
+            minval=-60, maxval=20,   #15 dBm Typ, up to 20 depending on F
+            units='dBm')
+        self.add_parameter('status', type=bool,
+            flags=Instrument.FLAG_GETSET)
+        
+        # Implement functions
+        self.get_all(True)
+
+        lockcount = 0
+        reference = _reference_class_conversion(reference)
+        self.set_reference(ReferenceSource.OCXO)
+        sleep(1)
+        self.set_reference(reference)
+        if reference == ReferenceSource.EXTERNAL:
+            for i in range(10):
+                if self.get_diag()["lock_xtal"] == "1":
+                    lockcount += 1
+            if lockcount == 0:
+                warnings.warn("No Lock possible. Check your reference. Defaulted to OCXO.")
+                self.set_reference(ReferenceSource.OCXO)
+            elif lockcount < 10:
+                warnings.warn("""External reference unstable. Check for sufficient 
+                                amplitude & accuracy. Defaulted to OCXO.""")
+                self.set_reference(ReferenceSource.OCXO)
+                print("WARNINK")
+            print(lockcount)
+
+    # initialization related
+    def get_all(self, query=True):
+        '''
+        Get Parameters (frequency, amplitude, output on/off, clock reference) of Device as dictionary
+        Input:
+            query (bool): Query from device (true) or relay local info (false)
+        Output:
+            Dictionary of device
+        '''
+        if not query:
+            return self._statusdict
+        self._statusdict = json.loads(self._rpc.readall())
+        self._frequency = float(self._statusdict["frequency"])
+        self._power = float(self._statusdict["amplitude"])
+        self._status = bool(int(self._statusdict["rfoutput"]))
+        refext = bool(int(self._statusdict["reference_int_ext"]))
+        refint = bool(int(self._statusdict["reference_tcxo_ocxo"]))
+        if refext:
+            self._reference = ReferenceSource.EXTERNAL
+        elif refint:
+            self._reference = ReferenceSource.OCXO
+        else:
+            self._reference = ReferenceSource.TCXO
+        return self._statusdict
+
+    def get_diag(self):
+        '''
+        Get diagnostics parameters (Firmware Versions, PLL locks status,
+             Voltage, Temperature) of Device as dictionary
+        Input:
+            None
+        Output:
+            Dictionary diagnostics parameters
+        '''
+        return json.loads(self._rpc.readdiag())
+
+    def set_reference(self, source):
+        '''
+        Set which 10MHz Reference to Use
+        Input:
+            source (ReferenceSource): External, Oven stabilized, Quarz stabilized
+        Output:
+            None
+        '''
+        try:
+            source = _reference_class_conversion(source)
+        except:
+            pass
+        if source is ReferenceSource.EXTERNAL:
+            self._rpc.setrefext()
+        elif source is ReferenceSource.OCXO:
+            self._rpc.setrefint()
+            self._rpc.setrefocxo()
+        elif source is ReferenceSource.TCXO:
+            self._rpc.setrefint()
+            self._rpc.setreftcxo()
+        else:
+            print(repr(source))
+            raise ValueError("Unknown ReferenceSource value.")
+        self._reference = source
+
+    def get_reference(self, query=True):
+        '''
+        Get which 10MHz reference is in use
+        Input:
+            query (bool): Refresh parameters from device memory if True
+        Output:
+            ReferenceSource: External = 0, Oven stabilized = 1, Quarz stabilized = 0
+        '''
+        self.get_all(query)
+        return self._reference
+
+    #Communication with device
+    def do_get_frequency(self, query=True):
+        '''
+        Get frequency of device
+        Input:
+            query (bool): Refresh parameters from device memory if True
+        Output:
+            microwave frequency (Hz)
+        '''
+        self.get_all(query)
+        return self._frequency
+        
+    def do_set_frequency(self, frequency):
+        '''
+        Set frequency of device
+        Input:
+            freq (float) : Frequency in Hz
+        Output:
+            None
+        '''
+        #logging.debug(__name__ + ' : setting frequency to %s Hz' % (frequency*1.0e9))
+        self._rpc.setfrequency(frequency)
+        self._frequency = frequency
+
+    def do_get_power(self, query=True):
+        '''
+        Get output power of device
+        Input:
+            query (bool): Refresh parameters from device memory if True
+        Output:
+            microwave power (dBm)
+        '''
+        self.get_all(query)
+        return self._power
+
+    def do_set_power(self,power = None):
+        '''
+        Typ. Max. Output 15 dB, Absolute Max. 20 dBm
+        Input:
+            power (float) : Power in dBm
+        Output:
+            None
+        '''
+        #logging.debug(__name__ + ' : setting power to %s dBm' % power)
+        self._power = power
+        self._rpc.setamplitude(power)
+
+    def do_get_status(self, query=True):
+        '''
+        Get status of output channel
+        Input:
+            query (bool): Refresh parameters from device memory if True
+        Output:
+            True (on) or False (off)
+        '''
+        self.get_all(query)
+        return self._status
+
+    def do_set_status(self,status):
+        '''
+        Set status of output (Bool)
+        Input:
+            status (bool): enable rf output(true), disable rf output (false)
+        Output:
+            None
+        '''
+        #logging.debug(__name__ + ' : setting status to "%s"' % status)
+        if status:
+            self._rpc.enableout()
+        else:
+            self._rpc.disableout()
+
+    #shortcuts
+    def off(self):
+        '''Turn RF Output Off'''
+        self.set_status(False)
+
+    def on(self):
+        '''Turn RF Ouput On'''
+        self.set_status(True)

--- a/qkit/services/raspi_misc/erasynth_server.py
+++ b/qkit/services/raspi_misc/erasynth_server.py
@@ -3,8 +3,9 @@ import time
 import sys
 import zerorpc
 
+
 class ERASynth(object):
-    def __init__(self, ttyname, verb = True):
+    def __init__(self, ttyname, verb=True):
         s = '/dev/tty'
         self.path = s + str(ttyname)
         self.ser = serial.Serial(self.path)
@@ -14,9 +15,9 @@ class ERASynth(object):
         if(self.ser.is_open == True):
             s = ""
             while s.find("HTTP server started") == -1:
-                s += self.ser.readline().decode("ascii")#.rstrip()
+                s += self.ser.readline().decode("ascii")  # .rstrip()
                 if(self.verbose):
-                    #sys.stdout.write(s)
+                    # sys.stdout.write(s)
                     print(s)
             print("Device: " + self.path)
             print("Initialization Complete")
@@ -34,7 +35,7 @@ class ERASynth(object):
             return s
         else:
             return s
-    
+
     def enableout(self):
         self.ser.write(b'>P01\r\n')
         return self.readln()
@@ -74,6 +75,7 @@ class ERASynth(object):
     def readdiag(self):
         self.ser.write(b'>RD\r\n')
         return self.readln()
+
 
 s = zerorpc.Server(ERASynth("ACM0", False))
 s.bind("tcp://0.0.0.0:4242")

--- a/qkit/services/raspi_misc/erasynth_server.py
+++ b/qkit/services/raspi_misc/erasynth_server.py
@@ -1,0 +1,90 @@
+import serial
+import time
+import sys
+import zerorpc
+
+class ERASynth(object):
+    def __init__(self, ttyname, verb = True):
+        s = '/dev/tty'
+        self.path = s + str(ttyname)
+        self.ser = serial.Serial(self.path)
+        self.ser.baudrate = 115200
+        self.verbose = verb
+
+        if(self.ser.is_open == True):
+            s = ""
+            while s.find("HTTP server started") == -1:
+                s += self.ser.readline().decode("ascii")#.rstrip()
+                if(self.verbose):
+                    #sys.stdout.write(s)
+                    print(s)
+            print("Device: " + self.path)
+            print("Initialization Complete")
+        else:
+            print("Error: Establishing connection Failed!")
+            print("Check permissions and connection.")
+
+    def __del__(self):
+        self.ser.close()
+
+    def readln(self):
+        s = self.ser.readline().decode("ascii").rstrip()
+        if(self.verbose):
+            print(s)
+            return s
+        else:
+            return s
+    
+    def enableout(self):
+        self.ser.write(b'>P01\r\n')
+        return self.readln()
+
+    def disableout(self):
+        self.ser.write(b'>P00\r\n')
+        return self.readln()
+
+    def setfrequency(self, f):
+        self.ser.write(b'>F' + str(int(f)).encode() + b'\r\n')
+        return self.readln()
+
+    def setamplitude(self, a):
+        self.ser.write(b'>A' + str(a).encode() + b'\r\n')
+        return self.readln()
+
+    def setrefint(self):
+        self.ser.write(b'>P10\r\n')  # Clock Ref internal
+        return self.readln()
+
+    def setrefext(self):
+        self.ser.write(b'>P11\r\n')  # Clock Ref internal
+        return self.readln()
+
+    def setrefocxo(self):
+        self.ser.write(b'>P51\r\n')  # OCXO
+        return self.readln()
+
+    def setreftcxo(self):
+        self.ser.write(b'>P50\r\n')  # TCXO
+        return self.readln()
+
+    def readall(self):
+        self.ser.write(b'>RA\r\n')  # Readl all as json
+        return self.readln()
+
+    def readdiag(self):
+        self.ser.write(b'>RD\r\n')
+        return self.readln()
+
+s = zerorpc.Server(ERASynth("ACM0", False))
+s.bind("tcp://0.0.0.0:4242")
+s.run()
+
+'''
+synth1 = ERASynth('ACM0')
+
+synth1.setfrequency(6,9)
+synth1.setamplitude(-22.2335)
+synth1.enableout()
+time.sleep(3)
+synth1.disableout()
+'''

--- a/qkit/services/raspi_misc/erasynth_server.py
+++ b/qkit/services/raspi_misc/erasynth_server.py
@@ -20,9 +20,9 @@ class ERASynth(object):
                     # sys.stdout.write(s)
                     print(s)
             print("Device: " + self.path)
-            print("Initialization Complete")
+            print("Initialization complete")
         else:
-            print("Error: Establishing connection Failed!")
+            print("Error: Establishing connection failed!")
             print("Check permissions and connection.")
 
     def __del__(self):


### PR DESCRIPTION
Add driver to control ERASynth via the network using a Raspberry Pi that is connected to the ERASynth device via USB.