### PR TITLE
Fid datadir

### DIFF
--- a/qkit/core/lib/file_service/file_info_database.py
+++ b/qkit/core/lib/file_service/file_info_database.py
@@ -80,8 +80,9 @@ import threading
 from distutils.version import LooseVersion
 
 import numpy as np
-
+import os
 import qkit
+import qkit.storage.hdf_DateTimeGenerator as dtg
 
 found_qgrid = False
 if qkit.module_available['pandas']:
@@ -105,9 +106,20 @@ class fid(file_system_service):
         self.create_database()
         self._selected_df = []
         self.found_qgrid = found_qgrid
+        if "fid_datadir" not in qkit.cfg:
+            qkit.cfg['fid_datadir'] = qkit.cfg['datadir']
+        elif qkit.cfg['fid_datadir'] is True:
+            self.restrict_to_userdir(True)
+        
         
 
     history = property(lambda self: sorted(self.h5_db.keys()))
+    
+    def restrict_to_userdir(self,restrict=True):
+        if restrict:
+            qkit.cfg['fid_datadir'] = os.path.split(dtg.DateTimeGenerator().new_filename()['_folder'])[0]
+        else:
+            qkit.cfg['fid_datadir'] = qkit.cfg['datadir']
     
     def get_last(self):
         return sorted(self.h5_db.keys())[-1]

--- a/qkit/core/lib/file_service/file_info_database.py
+++ b/qkit/core/lib/file_service/file_info_database.py
@@ -80,9 +80,8 @@ import threading
 from distutils.version import LooseVersion
 
 import numpy as np
-import os
+
 import qkit
-import qkit.storage.hdf_DateTimeGenerator as dtg
 
 found_qgrid = False
 if qkit.module_available['pandas']:
@@ -106,20 +105,9 @@ class fid(file_system_service):
         self.create_database()
         self._selected_df = []
         self.found_qgrid = found_qgrid
-        if "fid_datadir" not in qkit.cfg:
-            qkit.cfg['fid_datadir'] = qkit.cfg['datadir']
-        elif qkit.cfg['fid_datadir'] is True:
-            self.restrict_to_userdir(True)
-        
         
 
     history = property(lambda self: sorted(self.h5_db.keys()))
-    
-    def restrict_to_userdir(self,restrict=True):
-        if restrict:
-            qkit.cfg['fid_datadir'] = os.path.split(dtg.DateTimeGenerator().new_filename()['_folder'])[0]
-        else:
-            qkit.cfg['fid_datadir'] = qkit.cfg['datadir']
     
     def get_last(self):
         return sorted(self.h5_db.keys())[-1]

--- a/qkit/core/lib/file_service/file_info_database_lib.py
+++ b/qkit/core/lib/file_service/file_info_database_lib.py
@@ -113,7 +113,7 @@ class file_system_service(UUID_base):
             pickle.dump(self.h5_info_db,f,protocol=write_protocol)
 
     def _get_datadir(self):
-        if qkit.cfg['fid_restrict_to_userdir']:
+        if qkit.cfg.get('fid_restrict_to_userdir',False):
             return os.path.split(dtg.DateTimeGenerator().new_filename()['_folder'])[0]
         else:
             return qkit.cfg['datadir']

--- a/qkit/core/lib/file_service/file_info_database_lib.py
+++ b/qkit/core/lib/file_service/file_info_database_lib.py
@@ -118,7 +118,7 @@ class file_system_service(UUID_base):
             if qkit.cfg.get('fid_scan_datadir',True):
                 qkit.cfg['fid_scan_datadir'] = True
                 logging.debug("file info database: Start to update database.")
-                for root, _ , files in os.walk(qkit.cfg['datadir']): # root, dirs, files
+                for root, _ , files in os.walk(qkit.cfg['fid_datadir']): # root, dirs, files
                     for f in files:
                         self._inspect_and_add_Leaf(f,root)
                 logging.debug("file info database: Updating database done.")

--- a/qkit/core/lib/file_service/file_info_database_lib.py
+++ b/qkit/core/lib/file_service/file_info_database_lib.py
@@ -6,6 +6,7 @@ import logging
 import time
 import json
 import numpy as np
+import qkit.storage.hdf_DateTimeGenerator as dtg
 import h5py
 
 try:
@@ -111,6 +112,12 @@ class file_system_service(UUID_base):
         with open(self._h5_info_cache_path,'wb+') as f:
             pickle.dump(self.h5_info_db,f,protocol=write_protocol)
 
+    def _get_datadir(self):
+        if qkit.cfg['fid_restrict_to_userdir']:
+            return os.path.split(dtg.DateTimeGenerator().new_filename()['_folder'])[0]
+        else:
+            return qkit.cfg['datadir']
+
     def update_file_db(self):
         with self.lock:
             start_time = time.time()
@@ -118,7 +125,7 @@ class file_system_service(UUID_base):
             if qkit.cfg.get('fid_scan_datadir',True):
                 qkit.cfg['fid_scan_datadir'] = True
                 logging.debug("file info database: Start to update database.")
-                for root, _ , files in os.walk(qkit.cfg['fid_datadir']): # root, dirs, files
+                for root, _ , files in os.walk(self._get_datadir()): # root, dirs, files
                     for f in files:
                         self._inspect_and_add_Leaf(f,root)
                 logging.debug("file info database: Updating database done.")

--- a/qkit/core/lib/file_service/file_info_database_lib.py
+++ b/qkit/core/lib/file_service/file_info_database_lib.py
@@ -175,10 +175,12 @@ class file_system_service(UUID_base):
                 try:
                     tm = self.get_time(uuid)
                     dt = self.get_date(uuid)
+                    user = j_split[-3]
+                    run = j_split[-4]
                 except ValueError as e:
+                    user = None
+                    run = None
                     logging.info(e)
-                user = j_split[-3]
-                run = j_split[-4]
             else:
                 tm = uuid
                 try:


### PR DESCRIPTION
Add the ability to restrict the datadir scanned by fid to the current user's (i.e. run/user) data folder. This can make database generation faster for measurement PCs, where a lot of files are stored. 