### PR TITLE
Migration to py3 for some timedomain drivers/modules

### DIFF
--- a/qkit/drivers/Anritsu_MG37022.py
+++ b/qkit/drivers/Anritsu_MG37022.py
@@ -58,10 +58,6 @@ class Anritsu_MG37022(Instrument):
             flags=Instrument.FLAG_GETSET,
             minval=0, maxval=20e9,
             units='Hz',tags=['sweep'])
-        self.add_parameter('phase_offset', type=float,
-            flags=Instrument.FLAG_GETSET,
-            minval=-360, maxval=360,
-            units='deg')
         self.add_parameter('slope', type=float,
             flags=Instrument.FLAG_GETSET,
             minval=0, maxval=100,
@@ -74,6 +70,12 @@ class Anritsu_MG37022(Instrument):
             flags=Instrument.FLAG_GETSET)
         self.add_parameter('high_power', type=bool,
             flags=Instrument.FLAG_GETSET)
+
+        if ("MG3692C" not in self.ask("*IDN?").split(",")):
+            self.add_parameter('phase_offset', type=float,
+                flags=Instrument.FLAG_GETSET,
+                minval=-360, maxval=360,
+                units='deg')
         
         # Implement functions
         self.add_function('get_all')
@@ -96,7 +98,7 @@ class Anritsu_MG37022(Instrument):
         Output:
             microwave frequency (Hz)
         '''
-        self._frequency = float(self._visainstrument.ask('SOUR:FREQ:CW?'))
+        self._frequency = float(self._visainstrument.query('SOUR:FREQ:CW?'))
         return self._frequency
         
     def do_set_frequency(self, frequency):
@@ -148,7 +150,7 @@ class Anritsu_MG37022(Instrument):
         Output:
             microwave power (dBm)
         '''
-        self._power = float(self._visainstrument.ask('POW:LEV?'))
+        self._power = float(self._visainstrument.query('POW:LEV?'))
         return self._power
         
     def do_set_power(self,power = None):
@@ -183,7 +185,7 @@ class Anritsu_MG37022(Instrument):
         Output:
             True (on) or False (off)
         '''
-        stat = bool(int(self._visainstrument.ask('OUTP:STAT?')))
+        stat = bool(int(self._visainstrument.query('OUTP:STAT?')))
         return stat
         
     def do_set_status(self,status):
@@ -215,7 +217,7 @@ class Anritsu_MG37022(Instrument):
         Output:
             phase offset (deg)
         '''
-        return float(self._visainstrument.ask('PHAS:ADJ?'))
+        return float(self._visainstrument.query('PHAS:ADJ?'))
         
     def do_set_phase_offset(self, phase_offset):
         '''
@@ -280,4 +282,4 @@ class Anritsu_MG37022(Instrument):
     def write(self,msg):
       return self._visainstrument.write(msg)
     def ask(self,msg):
-      return self._visainstrument.ask(msg)
+      return self._visainstrument.query(msg)

--- a/qkit/drivers/HP_3245A.py
+++ b/qkit/drivers/HP_3245A.py
@@ -1,0 +1,188 @@
+# HP_3245A.py driver for Hewlett Packard 3245A Universal Source (current / voltage).
+# Sergey Danilin @University of Glasgow, 01/2020
+
+from qkit.core.instrument_base import Instrument
+from qkit import visa
+import types
+import logging
+import numpy as np
+
+class HP_3245A(Instrument):
+    '''
+	This is the python driver for the Hewlett Packard 3245A Universal Source
+
+	Usage: perform current or voltage sweep
+	Initialise with
+	<name> = qkit.instruments.create('<name>', 'HP_3245A', address='<GPIB address>', reset=<bool>)
+	
+	'''
+    def __init__(self, name, address, reset = False):
+        '''
+        Initializes the HP 3245A source, and communicates with the wrapper.
+
+        Input:
+            name (string)    : name of the instrument
+            address (string) : GPIB address
+            reset (bool)     : resets to default values
+
+        Output:
+            None
+        '''
+        # Initialize wrapper functions
+        logging.info(__name__ + ' : Initializing instrument HP_3245A')
+        Instrument.__init__(self, name, tags=['physical'])
+                
+        self._address = address
+        self._visainstrument = visa.instrument(self._address)
+      
+        self.add_function('reset')
+        self.add_function('clear_memory')
+        self.add_function('set_channel')
+        self.add_function('set_terminal')
+        self.add_function('set_output_type')
+        self.add_function('set_impedance')
+        self.add_function('set_resolution')
+        self.add_function('set_autorange')
+        self.add_function('set_current')
+        self.add_function('set_voltage')
+
+        self.reset()
+                    
+# functions to control the device
+
+    def reset(self, ch = 'CHANA'):
+        '''
+        Resets the source or a spesified channel of it.
+        Input: if none two channels of the source will be reset. If you specify the channel (string), then only that channel will be reset.
+        Output: NOne
+        '''
+        logging.debug(__name__ + ' : resetting HP_3245A.')
+        if ch in ['CHANA']:
+            self._visainstrument.write('RESET ' + ch)
+        elif ch in ['CHANB']:
+            self._visainstrument.write('RESET ' + ch)
+            logging.error('Channel B can not be reset. Entire source is reset.')
+        else:
+            logging.error('Unclear which channel to clear! Use CHANA for channel A, and CHANB for channel B.')
+    
+    def clear_memory(self):
+        '''
+        Clear the memory of the source.
+        Input: None
+        Output: None
+        '''
+        logging.debug(__name__ + ': clearing HP_3245A memory.')
+        self._visainstrument.write('SCRATCH')
+        
+    def set_channel(self, ch):
+        '''
+        Switches the source to the requested channel for parameter changes and operation.
+        Input: Channel name (string)
+        Output: None
+        '''
+        if ch in ['CHANA','CHANB','0','100']:
+            self._visainstrument.write('USE ' + ch)
+        else:
+            logging.error('Unclear which channel to set! Use CHANA for channel A, and CHANB for channel B.')
+            
+    def set_terminal(self, term):
+        '''
+        Selects the Front or Rear terminal for operation.
+        Input: Terminal desired (string)
+        Output: None
+        '''
+        if term in ['FRONT', 'REAR']:
+            logging.debug(__name__ + ': the output is from ' + term + 'terminal.')
+            self._visainstrument.write('TERM ' + term)
+        else:
+            logging.error('Unknown terminal! Use either FRONT or REAR.')
+            
+    def set_output_type(self, input_string):
+        ''' Sets the source for DC voltage / current output or triggered DC voltage / current output.
+        Input: string with the meaning  'DCV' - output DC voltages,
+                                        'DCI' - output DC cirrents,
+        Output: None'''
+        
+        if input_string in ['DCV', 'DCI']:
+            logging.debug(__name__ + ' : setting output type to' + input_string)
+            self._visainstrument.write('APPLY ' + input_string + ' 0')
+            self._output_type = input_string
+        else:
+            logging.error('''Not allowed DC output type! Can be one of: 'DCV','DCI'.''')
+            
+    def set_impedance(self, impedance):
+        ''' 
+        Sets the output impedance of the source if it is in voltage source mode.
+        Input: Desired output impedance (0 or 50 Ohm) (string '0' or '50')
+        '''
+        if self._output_type == 'DCV':
+            if impedance in ['0', '50']:
+                logging.debug(__name__ + ': setting output impedance to' + impedance)
+                self._visainstrument.write('IMP ' + impedance)
+            else:
+                logging.error('Not allowed impedance! 0 or 50 Ohm.')
+        else:
+            print('The output mode is not DCV. The output impedance is 0 Ohm and can not be changed!')
+            
+    def set_resolution(self, res):
+        '''
+        Sets the resolution of the source.
+        Input: Resolution desired ('HIGH' or 'LOW') in a string format.
+        Output: None
+        '''
+        if res in ['HIGH', 'LOW']:
+            logging.debug(__name__ + 'Setting the resolution to ' + res)
+            self._visainstrument.write('DCRES ' + res)
+        else:
+            logging.error('Not allowed resolution is given!')
+            
+    def set_autorange(self):
+        logging.debug(__name__ + 'setting the Autorange ON.')
+        self._visainstrument.write('ARANGE ON')
+        
+    def set_current(self, current):
+
+        '''
+        Sets the current from the source
+        
+        Input: Current in Ampears
+        
+        Output: None
+        '''
+        logging.debug(__name__ + ' : setting current to %s A' % current)
+        if (current < -1e-3):
+            self._visainstrument.write('APPLY DCI -%.1fE-3' % (abs(current)/1e-3))
+        elif (current >= -1e-3)&(current < -1e-6):
+            self._visainstrument.write('APPLY DCI -%.1fE-6' % (abs(current)/1e-6))
+        elif (current >= -1e-6)&(current < 0):
+            self._visainstrument.write('APPLY DCI -%.1fE-9' % (abs(current)/1e-9))
+        elif (current >= 0)&(current < 1e-6):
+            self._visainstrument.write('APPLY DCI %.1fE-9' % (abs(current)/1e-9))
+        elif (current >= 1e-6)&(current < 1e-3):
+            self._visainstrument.write('APPLY DCI %.1fE-6' % (abs(current)/1e-6))
+        else:
+            self._visainstrument.write('APPLY DCI %.1fE-3' % (abs(current)/1e-3))
+            
+    def set_voltage(self, voltage):
+
+        '''
+        Sets the voltage from the source
+        
+        Input: Voltage in Volts
+        
+        Output: None
+        '''
+        logging.debug(__name__ + ' : setting voltage to %s V' % voltage)
+        if (voltage < -1):
+            self._visainstrument.write('APPLY DCV -%.1fE-0' % (abs(voltage)))
+        elif (voltage >= -1)&(voltage < -1e-3):
+            self._visainstrument.write('APPLY DCV -%.1fE-3' % (abs(voltage)/1e-3))
+        elif (voltage >= -1e-3)&(voltage < 0):
+            self._visainstrument.write('APPLY DCV -%.1fE-6' % (abs(voltage)/1e-6))
+        elif (voltage >= 0)&(voltage < 1e-3):
+            self._visainstrument.write('APPLY DCV %.1fE-6' % (abs(voltage)/1e-6))
+        elif (voltage >= 1e-3)&(voltage < 1):
+            self._visainstrument.write('APPLY DCV %.1fE-3' % (abs(voltage)/1e-3))
+        else:
+            self._visainstrument.write('APPLY DCV %.1fE-0' % (abs(voltage)))
+            

--- a/qkit/drivers/Spectrum_M4i2211.py
+++ b/qkit/drivers/Spectrum_M4i2211.py
@@ -134,6 +134,7 @@ class Spectrum_M4i2211(Instrument):
         #self.add_function('_set_param')
 
         self.reset()
+        self.init_channel01_multiple_recording()
 
     def __del__(self):
         '''
@@ -164,43 +165,66 @@ class Spectrum_M4i2211(Instrument):
         '''
         if platform.architecture()[0] == '64bit':
             pf_64Bit = True
+            drv_handle= POINTER(c_uint64)
         else:
             pf_64Bit = False
+            drv_handle = c_void_p
 
         if pf_64Bit:
             logging.debug(__name__ + ' : Loading spcm_win64.dll')
             self._spcm_win32 = windll.LoadLibrary('C:\\WINDOWS\\System32\\spcm_win64.dll')
 
             #function names are not decorated in the 64 bit version
-            self._spcm_win32.open           = self._spcm_win32["spcm_hOpen"]
-            self._spcm_win32.close          = self._spcm_win32["spcm_vClose"]
-            self._spcm_win32.SetParam32     = self._spcm_win32["spcm_dwSetParam_i32"]
-            self._spcm_win32.SetParam64m    = self._spcm_win32["spcm_dwSetParam_i64m"]
-            self._spcm_win32.SetParam64     = self._spcm_win32["spcm_dwSetParam_i64"]
-            self._spcm_win32.GetParam32     = self._spcm_win32["spcm_dwGetParam_i32"]
-            self._spcm_win32.GetParam64m    = self._spcm_win32["spcm_dwGetParam_i64m"]
-            self._spcm_win32.GetParam64     = self._spcm_win32["spcm_dwGetParam_i64"]
-            self._spcm_win32.DefTransfer64m = self._spcm_win32["spcm_dwDefTransfer_i64m"]
-            self._spcm_win32.DefTransfer64  = self._spcm_win32["spcm_dwDefTransfer_i64"]
-            self._spcm_win32.InValidateBuf  = self._spcm_win32["spcm_dwInvalidateBuf"]
-            self._spcm_win32.GetErrorInfo   = self._spcm_win32["spcm_dwGetErrorInfo_i32"]
+            self._spcm_win32.open           = getattr (self._spcm_win32, "spcm_hOpen")
+            self._spcm_win32.close          = getattr (self._spcm_win32, "spcm_vClose")
+            self._spcm_win32.SetParam32     = getattr (self._spcm_win32, "spcm_dwSetParam_i32")
+            self._spcm_win32.SetParam64m    = getattr (self._spcm_win32, "spcm_dwSetParam_i64m")
+            self._spcm_win32.SetParam64     = getattr (self._spcm_win32, "spcm_dwSetParam_i64")
+            self._spcm_win32.GetParam32     = getattr (self._spcm_win32, "spcm_dwGetParam_i32")
+            #self._spcm_win32.GetParam64m    = self._spcm_win32["spcm_dwGetParam_i64m"]
+            self._spcm_win32.GetParam64     = getattr (self._spcm_win32, "spcm_dwGetParam_i64")
+            #self._spcm_win32.DefTransfer64m = self._spcm_win32["spcm_dwDefTransfer_i64m"]
+            self._spcm_win32.DefTransfer64  = getattr (self._spcm_win32, "spcm_dwDefTransfer_i64")
+            self._spcm_win32.InValidateBuf  = getattr (self._spcm_win32, "spcm_dwInvalidateBuf")
+            self._spcm_win32.GetErrorInfo   = getattr (self._spcm_win32, "spcm_dwGetErrorInfo_i32")
 
         else:
             logging.debug(__name__ + ' : Loading spcm_win32.dll')
             self._spcm_win32 = windll.LoadLibrary('C:\\WINDOWS\\System32\\spcm_win32')
 
-            self._spcm_win32.open           = self._spcm_win32["_spcm_hOpen@4"]
-            self._spcm_win32.close          = self._spcm_win32["_spcm_vClose@4"]
-            self._spcm_win32.SetParam32     = self._spcm_win32["_spcm_dwSetParam_i32@12"]
-            self._spcm_win32.SetParam64m    = self._spcm_win32["_spcm_dwSetParam_i64m@16"]
-            self._spcm_win32.SetParam64     = self._spcm_win32["_spcm_dwSetParam_i64@16"]
-            self._spcm_win32.GetParam32     = self._spcm_win32["_spcm_dwGetParam_i32@12"]
-            self._spcm_win32.GetParam64m    = self._spcm_win32["_spcm_dwGetParam_i64m@16"]
-            self._spcm_win32.GetParam64     = self._spcm_win32["_spcm_dwGetParam_i64@12"]
-            self._spcm_win32.DefTransfer64m = self._spcm_win32["_spcm_dwDefTransfer_i64m@36"]
-            self._spcm_win32.DefTransfer64  = self._spcm_win32["_spcm_dwDefTransfer_i64@36"]
-            self._spcm_win32.InValidateBuf  = self._spcm_win32["_spcm_dwInvalidateBuf@8"]
-            self._spcm_win32.GetErrorInfo   = self._spcm_win32["_spcm_dwGetErrorInfo_i32@16"]
+            self._spcm_win32.open           = getattr (self._spcm_win32, "_spcm_hOpen@4")
+            self._spcm_win32.close          = getattr (self._spcm_win32, "_spcm_vClose@4")
+            self._spcm_win32.SetParam32     = getattr (self._spcm_win32, "_spcm_dwSetParam_i32@12")
+            self._spcm_win32.SetParam64m    = getattr (self._spcm_win32, "_spcm_dwSetParam_i64m@16")
+            self._spcm_win32.SetParam64     = getattr (self._spcm_win32, "_spcm_dwSetParam_i64@16")
+            self._spcm_win32.GetParam32     = getattr (self._spcm_win32, "_spcm_dwGetParam_i32@12")
+            #self._spcm_win32.GetParam64m    = self._spcm_win32["_spcm_dwGetParam_i64m@16"]
+            self._spcm_win32.GetParam64     = getattr (self._spcm_win32, "_spcm_dwGetParam_i64@12")
+            #self._spcm_win32.DefTransfer64m = self._spcm_win32["_spcm_dwDefTransfer_i64m@36"]
+            self._spcm_win32.DefTransfer64  = getattr (self._spcm_win32, "_spcm_dwDefTransfer_i64@36")
+            self._spcm_win32.InValidateBuf  = getattr (self._spcm_win32, "_spcm_dwInvalidateBuf@8")
+            self._spcm_win32.GetErrorInfo   = getattr (self._spcm_win32, "_spcm_dwGetErrorInfo_i32@16")
+
+        self._spcm_win32.open.argtype = [c_char_p]
+        self._spcm_win32.open.restype = drv_handle
+        self._spcm_win32.close.argtype = [drv_handle]
+        self._spcm_win32.close.restype = None
+        self._spcm_win32.SetParam32.argtype = [drv_handle, c_int32, c_int32]
+        self._spcm_win32.SetParam32.restype = c_uint32
+        self._spcm_win32.SetParam64m.argtype = [drv_handle, c_int32, c_int32, c_int32]
+        self._spcm_win32.SetParam64m.restype = c_uint32
+        self._spcm_win32.SetParam64.argtype = [drv_handle, c_int32, c_int64]
+        self._spcm_win32.SetParam64.restye = c_uint32
+        self._spcm_win32.GetParam32.argtype = [drv_handle, c_int32, POINTER (c_int32)]
+        self._spcm_win32.GetParam32.restype = c_uint32
+        self._spcm_win32.GetParam64.argtype = [drv_handle, c_int32, POINTER (c_int64)]
+        self._spcm_win32.GetParam64.restype = c_uint32
+        self._spcm_win32.DefTransfer64.argtype = [drv_handle, c_uint32, c_uint32, c_uint32, c_void_p, c_uint64, c_uint64]
+        self._spcm_win32.DefTransfer64.restype = c_uint32
+        self._spcm_win32.InValidateBuf.argtype = [drv_handle, c_uint32]
+        self._spcm_win32.InValidateBuf.restype = c_uint32
+        self._spcm_win32.GetErrorInfo.argtype = [drv_handle, POINTER (c_uint32), POINTER (c_int32), c_char_p]
+        self._spcm_win32.GetErrorInfo.restype = c_uint32
 
     def _open(self):
         '''
@@ -215,7 +239,7 @@ class Spectrum_M4i2211(Instrument):
         '''
         logging.debug(__name__ + ' : Try to open card')
         if ( not self._card_is_open):
-          self._spcm_win32.handel = self._spcm_win32.open('spcm0')
+          self._spcm_win32.handel = self._spcm_win32.open(create_string_buffer (b'spcm0'))
           self._card_is_open = True
         else:
           logging.warning(__name__ + ' : Card is already open !')
@@ -383,11 +407,11 @@ class Spectrum_M4i2211(Instrument):
 
         self._spcm_win32.GetErrorInfo(self._spcm_win32.handel, p_er1, p_er2, p_errortekst)
 
-        tekst = ""
+        tekst = b""
 
         for ii in range(200):
             tekst  = tekst + p_errortekst.contents[ii]
-        logging.error(__name__ + ' : ' + tekst)
+        logging.error(__name__ + ' : ' + str(tekst))
         return tekst
 
 
@@ -557,6 +581,7 @@ class Spectrum_M4i2211(Instrument):
         self._spcm_win32.SetParam32(self._spcm_win32.handel, _spcm_regs.SPC_TRIG_CH_ORMASK1,     0);
         self._spcm_win32.SetParam32(self._spcm_win32.handel, _spcm_regs.SPC_TRIG_CH_ANDMASK0,    0);
         self._spcm_win32.SetParam32(self._spcm_win32.handel, _spcm_regs.SPC_TRIG_CH_ANDMASK1,    0);
+
         self.set_trigger_ext0_level0(800)
         self.set_trigger_ext0_level1(200)
         self.set_clock_50Ohm()
@@ -617,10 +642,12 @@ class Spectrum_M4i2211(Instrument):
         self._spcm_win32.SetParam32(self._spcm_win32.handel, _spcm_regs.SPC_TRIG_CH_ORMASK1,     0);
         self._spcm_win32.SetParam32(self._spcm_win32.handel, _spcm_regs.SPC_TRIG_CH_ANDMASK0,    0);
         self._spcm_win32.SetParam32(self._spcm_win32.handel, _spcm_regs.SPC_TRIG_CH_ANDMASK1,    0);
+
         self.set_trigger_ext0_level0(800)
         self.set_trigger_ext0_level1(200)
         self.set_clock_50Ohm()
-        self.set_clockmode_ext()
+        #self.set_clockmode_ext()
+        self.set_clockmode_pll()
 
 #########################
 ### General
@@ -710,7 +737,7 @@ class Spectrum_M4i2211(Instrument):
         logging.debug(__name__ + ' : Card started with trigger')
         self._buffer_setup()
         self._set_param(_spcm_regs.SPC_M2CMD,
-            _spcm_regs.M2CMD_CARD_START | _spcm_regs.M2CMD_CARD_ENABLETRIGGER)
+            _spcm_regs.M2CMD_CARD_START | _spcm_regs.M2CMD_CARD_ENABLETRIGGER | _spcm_regs.M2CMD_DATA_STARTDMA)
 
     def start_with_trigger_and_waitready(self):
         '''
@@ -1363,7 +1390,6 @@ class Spectrum_M4i2211(Instrument):
         if data == 'timeout':
             return data
         data = numpy.array(data, numpy.float32)
-        data = []
         data = 2.0 * amp * (data / 255.0) + offset
         return data
 
@@ -1371,7 +1397,7 @@ class Spectrum_M4i2211(Instrument):
         lMemsize = self.get_memsize()
         lSegsize = self.get_segmentsize()
 
-        lnumber_of_segments = lMemsize / lSegsize
+        lnumber_of_segments = int(lMemsize / lSegsize)
 
         data = self.readout_raw_buffer()
         if data == 'timeout':
@@ -1386,7 +1412,7 @@ class Spectrum_M4i2211(Instrument):
         amp = float(self.get_input_amp_ch0())
         offset = float(self.get_input_offset_ch0())
 
-        lnumber_of_segments = lMemsize / lSegsize
+        lnumber_of_segments = int(lMemsize / lSegsize)
 
         data = self.readout_raw_buffer()
         if data == 'timeout':
@@ -1423,7 +1449,7 @@ class Spectrum_M4i2211(Instrument):
         lMemsize = self.get_memsize()
         lSegsize = self.get_segmentsize()
 
-        lnumber_of_segments = lMemsize / lSegsize
+        lnumber_of_segments = int(lMemsize / lSegsize)
 
         data = self.readout_raw_buffer(nr_of_channels=2)
         if data == 'timeout':
@@ -1441,7 +1467,7 @@ class Spectrum_M4i2211(Instrument):
         amp1 = float(self.get_input_amp_ch0())
         offset1 = float(self.get_input_offset_ch1())
 
-        lnumber_of_ssegments = lMemsize / lSegsize
+        lnumber_of_segments = int(lMemsize / lSegsize)
 
         data = self.readout_raw_buffer(nr_of_channels=2)
         if data == 'timeout':

--- a/qkit/drivers/Tabor_WX1284C.py
+++ b/qkit/drivers/Tabor_WX1284C.py
@@ -35,10 +35,10 @@ import pyvisa.constants as vc
 
 class Tabor_WX1284C(Instrument):
     '''
-    This is the python driver for the Tabor Electronics Arbitrary Waveform Generator WX1284C
+    This is the python driver for the Tabor Electronics Arbitrary Waveform Generator WX1284C/WX2184C
     '''
 
-    def __init__(self, name, address, chpair=None, reset=False, clock=6e9, numchannels = 4):
+    def __init__(self, name, address, chpair=None, reset=False, numchannels = 4):
         '''
         Initializes the AWG WX1284C
         Input:
@@ -61,7 +61,7 @@ class Tabor_WX1284C(Instrument):
             self._visainstrument.timeout=2
         else:
             self._visainstrument = visa.instrument(self._address)
-            self._visainstrument.timeout=2000L
+            self._visainstrument.timeout=2000
             self._visainstrument.visalib.set_buffer(self._visainstrument.session, vc.VI_READ_BUF, 4000)
             self._visainstrument.visalib.set_buffer(self._visainstrument.session, vc.VI_WRITE_BUF, 32000)
 
@@ -86,7 +86,7 @@ class Tabor_WX1284C(Instrument):
         
         self._values = {}
         self._values['files'] = {}
-        self._clock = clock
+        self._clock = 1e9
 
         if chpair not in [None, 1, 2]:
             raise ValueError("chpair should be 1, 2 or None.")
@@ -224,15 +224,15 @@ class Tabor_WX1284C(Instrument):
         if not self._ins_VISA_INSTR:
             tmo= self._visainstrument.timeout
             self._visainstrument.timeout = .1
-            if verbose: print "Emptying Queue"
+            if verbose: print("Emptying Queue")
             try:
                 for i in range(200):
                     rl = str(self._visainstrument.read())
-                    if verbose: print "In Buffer %i: "%i+rl
+                    if verbose: print("In Buffer %i: "%i+rl)
             except visa.VisaIOError:
-                if verbose: print "Timeout after %i iterations"%i
+                if verbose: print("Timeout after %i iterations"%i)
             self._visainstrument.timeout = tmo
-        if verbose: print "Clearing Error Memory:"
+        if verbose: print("Clearing Error Memory:")
         for i in range(200):
             try:
                 if self.check():
@@ -348,7 +348,7 @@ class Tabor_WX1284C(Instrument):
         try:
             self.set_trigger_slope(tr_slope)
         except Exception as m:
-            print 'Trigger slope has to be POS or NEG. Setting to NEG.', m
+            print('Trigger slope has to be POS or NEG. Setting to NEG.', m)
             self.set_trigger_slope('NEG')
 
     def preset_manipulation(self):
@@ -381,7 +381,7 @@ class Tabor_WX1284C(Instrument):
                 return self._visainstrument.ask(cmd).strip()
             except visa.VisaIOError as e:
                 logging.debug(__name__ + "(" +self.get_name()+"): VisaIOError, retry ->%s<-"%e)
-        raise ValueError(__name__ + "(" +self.get_name()+"): ask('%s') not successful after 15 retries ->%s<-"%(cmd[0:100],e))
+        raise ValueError(__name__ + "(" +self.get_name()+"): ask('%s') not successful after 15 retries"%(cmd[0:100]))
 
     def write(self,cmd):
         for i in range(15):
@@ -390,7 +390,7 @@ class Tabor_WX1284C(Instrument):
                 return self._visainstrument.write(cmd)
             except visa.VisaIOError as e:
                 logging.debug(__name__ + "(" +self.get_name()+") :VisaIOError, retry ->%s<-"%e)
-        raise ValueError(__name__ + "(" +self.get_name()+") : write('%s') not successful after 15 retries ->%s<-"%(cmd[0:100],e))
+        raise ValueError(__name__ + "(" +self.get_name()+") : write('%s') not successful after 15 retries"%(cmd[0:100]))
 
     def write_raw(self,cmd):
         if visa.qkit_visa_version == 1:
@@ -831,10 +831,10 @@ class Tabor_WX1284C(Instrument):
             % (channel, amp))
         if amp < 50e-3:
             amp = 50e-3
-            print 'amplitude was set to 0.05 V, which is smallest possible voltage'
+            print('amplitude was set to 0.05 V, which is smallest possible voltage')
         if amp > 2:
             amp = 2.
-            print 'amplitude was set to 2 V, which is highest possible voltage'
+            print('amplitude was set to 2 V, which is highest possible voltage')
 
         self.write(':INST%s;:VOLT%.3f' % (channel, amp))
 
@@ -863,10 +863,10 @@ class Tabor_WX1284C(Instrument):
         channel +=self._choff
         if offset < -1.000:
             offset = -1.000
-            print 'Offset was set to -1.000 V, which is smallest possible voltage'
+            print('Offset was set to -1.000 V, which is smallest possible voltage')
         if offset > 1.000:
             offset = 1.000
-            print 'Offset was set to 1.000 V, which is highest possible voltage'
+            print('Offset was set to 1.000 V, which is highest possible voltage')
 
         logging.debug(__name__ + ' : Set offset of channel %s to %.3f' % (channel, offset))
         self.write(':INST%s;:VOLT:OFFS%.3f' % (channel, offset))
@@ -985,7 +985,7 @@ class Tabor_WX1284C(Instrument):
             (string) : 10e6, 20e6, 50e6, 100e6
         '''
         logging.debug(__name__ + ' : Get clock reference frequency.')
-        return float(self.ask(':ROSC:FREQ ?'))
+        return int(self.ask(':ROSC:FREQ ?')[:-1])*1.0e6
 
     def do_set_common_clock(self,status=True):
         '''
@@ -1040,12 +1040,10 @@ class Tabor_WX1284C(Instrument):
 
         channel +=self._choff
 
-        dim = len(w)
-
         if len(w)%16 != 0:
             raise ValueError #wfm length has to be divisible by 16
         if len(w) < 192:
-            w = numpy.append(w1, numpy.zeros(192 - len(w)))
+            w = numpy.append(w, numpy.zeros(192 - len(w)))
             m1 = numpy.append(m1, numpy.zeros(192 - len(m1)))
             m2 = numpy.append(m2, numpy.zeros(192 - len(m2)))
 
@@ -1062,11 +1060,11 @@ class Tabor_WX1284C(Instrument):
         #set set single trace transfer mode
         self.write(':TRAC:MODE SING')
 
-        ws = ''
+        ws = b''
         for i in range(0,len(w)):
-            ws = ws + struct.pack('<H', 8191*w[i]+8192+m1[i]*2**14+m2[i]*2**15)
+            ws = ws + struct.pack('<H', int(8191*w[i]+8192+m1[i]*2**14+m2[i]*2**15))
 
-        self.write_raw(':TRAC#%i%i%s' %(int(numpy.log10(len(ws))+1), len(ws), ws))
+        self.write_raw(b':TRAC#%i%i%s' %(int(numpy.log10(len(ws))+1), len(ws), ws))
 
     def wfm_send2(self, w1, w2, m1=None, m2=None, channel=1, seg=1):
         '''
@@ -1107,10 +1105,11 @@ class Tabor_WX1284C(Instrument):
         #set set combined trace transfer mode
         self.write(':TRAC:MODE COMB')
 
-        wfm = numpy.append(numpy.reshape(numpy.array(8191*w2+8192+m1*2**14+m2*2**15,dtype=numpy.dtype('<H')),(-1,16)),numpy.reshape(numpy.array(8191*w1+8192+m1*2**14+m2*2**15,dtype=numpy.dtype('<H')),(-1,16)),axis=1).flatten()
-        ws =str(buffer(wfm))
+        wfm = numpy.append(numpy.reshape(numpy.array(8191*w2+8192+m1*2**14+m2*2**15,dtype=numpy.dtype('<H')),(-1,16)),\
+                        numpy.reshape(numpy.array(8191*w1+8192+m1*2**14+m2*2**15,dtype=numpy.dtype('<H')),(-1,16)),axis=1).flatten()
+        ws = bytes(memoryview(wfm))
 
-        self.write_raw(':TRAC#%i%i%s' %(int(numpy.log10(len(ws))+1), len(ws), ws))
+        self.write_raw(b':TRAC#%i%i%s' %(int(numpy.log10(len(ws))+1), len(ws), ws))
 
 
     def define_sequence(self,channel, segments=None,loops=None,jump_flags=None):
@@ -1123,7 +1122,7 @@ class Tabor_WX1284C(Instrument):
         '''
         channel +=self._choff
         if segments is None:
-            print "Amount of segments not specified, try to get it from AWG"
+            print("Amount of segments not specified, try to get it from AWG")
             for i in range(1,32000):
                 if int(self.ask(":TRAC:DEF%i?"%i).split()[-1])==0:
                     segments = i-1
@@ -1135,18 +1134,18 @@ class Tabor_WX1284C(Instrument):
             if segments == 1 : segments = [1,1,1]
             elif segments == 2 : segments = [1,2,1,2]
             else: segments = range(1,segments+1)
-        if loops == None: loops = numpy.ones(len(segments))
-        if jump_flags == None: jump_flags = numpy.zeros(len(segments))
+        if loops == None: loops = numpy.ones(len(segments),dtype=numpy.uint)
+        if jump_flags == None: jump_flags = numpy.zeros(len(segments),dtype=numpy.ushort)
         if not len(loops)==len(segments) or not len(jump_flags) == len(segments):
             raise ValueError("Length of segments (%i) does not match length of loops (%i) or length of jump_flags(%i)"%(len(segments),len(loops),len(jump_flags)))
         if len(segments)<3: raise ValueError("Sorry, you need at least 3 segments. Your command has %i segments"%(len(segments)))
 
         #Set specified channel
         self.write(':INST%s' % (channel))
-        ws = ''
+        ws = b''
         for i in range(len(segments)):
             ws = ws + struct.pack('<LHH', loops[i],segments[i],jump_flags[i])
-        self.write_raw(':SEQ#%i%i%s' %(int(numpy.log10(len(ws))+1), len(ws), ws))
+        self.write_raw(b':SEQ#%i%i%s' %(int(numpy.log10(len(ws))+1), len(ws), ws))
 
     def set_seq_length(self,length,chpair=1):
         self.define_sequence((2*chpair-1 if self._numchannels == 4 else chpair),length)

--- a/qkit/drivers/virtual_MultiplexingReadout.py
+++ b/qkit/drivers/virtual_MultiplexingReadout.py
@@ -489,8 +489,6 @@ class virtual_MultiplexingReadout(Instrument):
                 if int(self._awg.ask(":TRAC:DEF%i?"%i).split()[-1])==0:
                     seg_n = i
                     break
-            plt.plot(samples[0])
-            plt.plot(marker1[0])
             self._awg.wfm_send2(samples[0],samples[1],m1 = marker1[0],m2 = marker2[0],channel=self._dac_channel_I, seg=seg_n)
             self._awg.define_sequence(self._dac_channel_I,[seg_n,seg_n,seg_n])
 

--- a/qkit/drivers/virtual_measure_spec.py
+++ b/qkit/drivers/virtual_measure_spec.py
@@ -67,7 +67,7 @@ class virtual_measure_spec(Instrument):
         self.add_parameter('segments', type=int)
         self.add_parameter('averages', type=int)
         self.add_parameter('blocks', type=int)
-        self.add_parameter('offsets', type=types.ListType)
+        self.add_parameter('offsets', type=list)
         self.add_parameter('channels', type=int)
         self.add_parameter('multimode', type=bool)
         self.add_parameter('trigger_rate', type=float)
@@ -178,11 +178,11 @@ class virtual_measure_spec(Instrument):
         '''
         Sets the start and end of the acquisition window. These values can be chosen arbitrarily and do not have to be divisible by 16 or 32.
         '''
-        c_start = int(start) / self.bit_blocksize  # floor
+        c_start = int(start) // self.bit_blocksize  # floor
         c_start *= self.bit_blocksize
         # self.bit_pre = int(start) - c_start
         samples = int(end) - c_start
-        c_samples = (samples + self.bit_blocksize - 1) / self.bit_blocksize  # ceil
+        c_samples = (samples + self.bit_blocksize - 1) // self.bit_blocksize  # ceil
         c_samples *= self.bit_blocksize
         # self.bit_post = c_samples - samples
         # print "setting card to %g samples and a delay of %g"%(c_samples,c_start)
@@ -295,6 +295,10 @@ class virtual_measure_spec(Instrument):
             result = self._acquire_multimode()
         else:
             result = self._acquire_singlemode()
+
+        #reset gate_func ("stop" awg output)
+        self._gate_func(False)
+
         # apply offsets
         if (self._offsets != None):
             for idx in range(len(self._offsets)):
@@ -375,7 +379,7 @@ class virtual_measure_spec(Instrument):
             err = self._dacq.waitready()
             if (err == 263):
                 print('measure_spec: Timeout during data acquisition.')
-                return None;
+                return None
         else:
             status = self._dacq.get_card_status()
             # 'ready' or 'waitdma' flag, see p138 of the manual
@@ -413,10 +417,10 @@ class virtual_measure_spec(Instrument):
     def _multimode_average(self, dat):
         ''' faster-than-numpy averaging '''
         shp = dat.shape
-        sum = numpy.zeros((shp[0], shp[2]), np.int)
+        sum = numpy.zeros((shp[0], shp[2]), numpy.int)
         for i in range(shp[1]):
             sum += dat[:, i, :]
-        return np.array(res, np.float32) / shp[1]
+        return numpy.array(res, numpy.float32) / shp[1]
 
     def _acquire_singlemode(self):
         '''

--- a/qkit/measure/timedomain/VirtualAWG.py
+++ b/qkit/measure/timedomain/VirtualAWG.py
@@ -520,15 +520,15 @@ class VirtualAWG(object):
             ind += 1
         return sequences, readout_indices
     
-    def load(self, show_progress_bar=True):
+    def load(self, reset=True, show_progress_bar=True):
         """
         Load the sequences stored in the channels of the virtual AWG to your physical device (awg, fpga).
         Currently only enabled for the tabor awg.
         """
         # Case descrimination:
-        if self._sample.awg.get_name() is "tawg":
+        if self._sample.awg.get_type() is "Tabor_WX1284C":
             sequences, readout_inds = self._sync()
-            load_tawg.load_tabor(sequences, readout_inds, self._sample, show_progress_bar=show_progress_bar)
+            load_tawg.load_tabor(sequences, readout_inds, self._sample, reset=reset, show_progress_bar=show_progress_bar)
         else:
             print("Unknown device type! Unable to load sequences.")
         return True

--- a/qkit/measure/timedomain/awg/load_tawg.py
+++ b/qkit/measure/timedomain/awg/load_tawg.py
@@ -99,6 +99,12 @@ def load_tabor(channel_sequences, ro_index, sample, reset=True, show_progress_ba
 
     if reset:
         _reset(awg, number_of_channels, ro_index)
+    else:
+        if number_of_channels <= 2:
+            awg.define_sequence(1, len(ro_index))
+        else:
+            awg.define_sequence(3, len(ro_index))
+
     # Loading the waveforms into the AWG, differentiating between all cases
     if show_progress_bar:
         p = Progress_Bar(len(ro_index), 'Load AWG')

--- a/qkit/measure/timedomain/gate_func.py
+++ b/qkit/measure/timedomain/gate_func.py
@@ -67,9 +67,17 @@ class Gate_Func(object):
         self.selftriggered = (self.pulser == None and self.ni_daq == None)
         
         if self.selftriggered:
-            self._gate_low  =  lambda: self.awg.set({'trigger_time':2, 'p1_trigger_time':2})
-            self._gate_high = lambda: self.awg.set({'trigger_time':sample.T_rep, 'p1_trigger_time':sample.T_rep})
-        
+            if 'Tabor' in self.awg.get_type():
+                if (awg._numchannels == 4):
+                    self._gate_low  =  lambda: self.awg.set({'p1_trigger_time':2,'p2_trigger_time':2})
+                    self._gate_high =  lambda: self.awg.set({'p1_trigger_time':sample.T_rep, 'p2_trigger_time':sample.T_rep})
+                else:
+                    self._gate_low  =  lambda: self.awg.set({'trigger_time':2})
+                    self._gate_high =  lambda: self.awg.set({'trigger_time':sample.T_rep})
+            else:
+                self._gate_low  =  lambda: self.awg.set({'trigger_time':2,'p1_trigger_time':2})
+                self._gate_high =  lambda: self.awg.set({'trigger_time':sample.T_rep, 'p1_trigger_time':sample.T_rep})
+
         if self.selftriggered and not ('Tabor' in self.awg.get_type()):
             raise ValueError("selftriggered mode (without pulser and nidaq) is currently only available for Tabor AWGs.")
         self.ni_daq_ch = ni_daq_ch
@@ -113,10 +121,10 @@ class Gate_Func(object):
             self.awg.wait()
             self.awg.run()
             #self.awg.wait()
-            time.sleep(0.05*seq_it)
+            #time.sleep(0.05*seq_it)
 
         if tries > 4:
-            print 'Tektronix AWG reached first waveform after %d iterations.'%tries
+            print('Tektronix AWG reached first waveform after %d iterations.'%tries)
                 
     def _reset_tabor(self):
         """

--- a/qkit/measure/timedomain/pulse_sequence.py
+++ b/qkit/measure/timedomain/pulse_sequence.py
@@ -195,7 +195,7 @@ class PulseSequence(object):
             logging.error("Sequence call requires samplerate.")
             return
         
-        if kwargs.has_key("IQ_mixing"):
+        if "IQ_mixing" in kwargs:
             IQ_mixing = kwargs["IQ_mixing"]
         else:
             IQ_mixing = False


### PR DESCRIPTION
We have been correcting some of the drivers and modules for the TD part of qkit to work with python3. We also noticed that some of the code only works for a specific TD setup (like two separate AWGs for control and readout pulses), so we fixed some of it to, at least, work with our current setup (Tabor AWG for readout and control). This is just an initial update, probably we will find more things to change for py3 in the near future.

Cheers,
João