### PR TITLE
Bugfix to circle version selected

### DIFF
--- a/qkit/config/environment.py
+++ b/qkit/config/environment.py
@@ -35,6 +35,11 @@ cfg['datadir'] = os.path.join(cfg['qkitdir'],'data')
 cfg['instruments_dir']      = os.path.join(cfg['qkitdir'],'drivers')
 cfg['user_instruments_dir'] = None
 
+##
+## Set circle fit version for resonator class
+##
+cfg['circle_fit_version'] = 2
+
 
 ##
 ## Save data with the new naming scheme


### PR DESCRIPTION
Addressing a bug in resonator.py. 

![image](https://user-images.githubusercontent.com/82719159/125828240-36089d4b-75f4-4c2e-9b4d-0644cd0decc0.png)

- From what I can tell, circle_fit_version is set in https://github.com/qkitgroup/qkit/blob/master/qkit/analysis/resonator.py on line 289, where it is read in from the config: ` circle_fit_version = qkit.cfg.get("circle_fit_version", 1)` 
- I don't know another way to change circle_fit_version than to update the config
- Alternative fixes: 
    - remove the if/elif and just use circle fit version 2
    - make the circle_fit_version an argument
    - a better explanation of how to update the config

- Bug occurs in https://github.com/qkitgroup/qkit/blob/master/qkit/analysis/resonator.py on line 281 ` self._results[str(key)].append(float(self._circle_port.fitresults[str(key)]))` because the keys in _results do not align with the keys in _circle_port.fitresults
- this happens in in _do_fit_circle() which is called in fit_circle()
- switching to circle_fit_version = 2 makes the keys the same and thus corrects the bug