### PR TITLE
Feature/parameter offset

### DIFF
--- a/qkit/core/instrument_base.py
+++ b/qkit/core/instrument_base.py
@@ -67,6 +67,7 @@ class Instrument(object):
         self._functions = {}
         self._added_methods = []
         self._probe_ids = []
+        self._offsets = {}
 
     def __str__(self):
         return "Instrument '%s'" % (self.get_name())
@@ -211,6 +212,8 @@ class Instrument(object):
             options['type'] = type(None)
         if 'tags' not in options:
             options['tags'] = []
+        if 'offset' not in options:
+            options['offset'] = False
 
         # If defining channels call add_parameter for each channel
         if 'channels' in options:
@@ -236,6 +239,7 @@ class Instrument(object):
             return
 
         self._parameters[name] = options
+        self._offsets[name] = None
 
         if 'channel' in options:
             ch = options['channel']
@@ -243,6 +247,20 @@ class Instrument(object):
             ch = None
 
         base_name = kwargs.get('base_name', name)
+
+        if options['offset']:
+            if options["type"] in (bool,bytes,str):
+                raise ValueError("%s.%s: Offset not available for parameter with type %s" % (self._name, name, options["type"].__name__))
+            else:
+                func = lambda value: self._offsets.update({name:value})
+                func.__doc__ = """Set an offset for parameter %s on device %s.
+                The offset is added on every get and substracted on every set command.
+                Use e.g. set_power_offset(-20) if you add 20dB attenuation at the device."""%(self._name,name)
+                setattr(self, 'set_%s_offset' % name, func)
+                self._added_methods.append('set_%s_offset' % name)
+    
+                setattr(self, 'get_%s_offset' % name, lambda : self._offsets[name])
+                self._added_methods.append('get_%s_offset' % name)
 
         if options['flags'] & Instrument.FLAG_GET:
             if ch is not None:
@@ -505,6 +523,11 @@ class Instrument(object):
         Return a dictionary with parameter group name -> group members.
         '''
         return self._parameter_groups
+    
+    def _offset(self,name,value,sign):
+        if self._offsets[name] is not None:
+            return value+sign*self._offsets[name]
+        return value
 
     def _get_value(self, name, query=True, **kwargs):
         '''
@@ -529,9 +552,9 @@ class Instrument(object):
         if not query or flags & 8: #self.FLAG_SOFTGET:
             if 'value' in p:
                 if p['type'] == np.ndarray:
-                    return np.array(p['value'])
+                    return self._offset(name,np.array(p['value']),+1)
                 else:
-                    return p['value']
+                    return self._offset(name,p['value'],+1)
             elif not query:
                 if not flags & 1: #Instrument.FLAG_GET, not gettable
                     return None 
@@ -562,7 +585,7 @@ class Instrument(object):
                 logging.warning('Unable to cast value "%s" to %s', value, p['type'])
 
         p['value'] = value
-        return value
+        return self._offset(name,value,+1)
 
     def get(self, name, query=True, fast=False, **kwargs):
         '''
@@ -643,13 +666,21 @@ class Instrument(object):
         if 'channel' in p and 'channel' not in kwargs:
             kwargs['channel'] = p['channel']
 
+        value = self._offset(name, value, -1)
+
         if 'type' in p:
             value = self._convert_value(value, p['type'])
 
         if 'minval' in p and value < p['minval']:
+            if self._offsets[name] is not None and self._offsets[name] != 0:
+                raise qkit.instruments.InstrumentBoundsError('Cannot set %s.%s to %g: With offset %g, %s at %s would be %g, which is too small (Minimum: '
+                                                             '%g)' % (self._name, name, value+self._offsets[name],self._offsets[name],name,self._name,value, p['maxval']))
             raise qkit.instruments.InstrumentBoundsError('Cannot set %s.%s to %s: value too small (Minimum: %g)' % (self._name, name,value, p['minval']))
 
         if 'maxval' in p and value > p['maxval']:
+            if self._offsets[name] is not None and self._offsets[name] != 0:
+                raise qkit.instruments.InstrumentBoundsError('Cannot set %s.%s to %g: With offset %g, %s at %s would be %g, which is too large (Maximum: '
+                                                             '%g)' % (self._name, name, value+self._offsets[name],self._offsets[name],name,self._name,value, p['maxval']))
             raise qkit.instruments.InstrumentBoundsError('Cannot set %s.%s to %s: value too large (Maximum: %g)' % (self._name, name, value, p['maxval']))
 
         func = p['set_func']
@@ -667,7 +698,7 @@ class Instrument(object):
         func(value, **kwargs)  # execute the set function to get the final value
 
         if p['flags'] & self.FLAG_GET_AFTER_SET:
-            newvalue = self._get_value(name, **kwargs)
+            newvalue = self._offset(name,self._get_value(name, **kwargs),-1)
             if newvalue != value:
                 logging.warning("%s.%s: actual value (%s) differs from set value (%s)"%(self._name,name,newvalue,value))
             value = newvalue

--- a/qkit/drivers/DummyVNA.py
+++ b/qkit/drivers/DummyVNA.py
@@ -37,6 +37,7 @@ class DummyVNA(Instrument):
         self.span = self.stopfreq - self.startfreq
         self.centerfreq = (self.startfreq + self.stopfreq) / 2
         self._ready = False
+        self.add_parameter('power', type=float, minval=-85, maxval=10, units='dBm',offset=True,flags=Instrument.FLAG_GET_AFTER_SET|Instrument.FLAG_GETSET)
         self.add_function('get_freqpoints')
         self.add_function('get_tracedata')
         self.add_function('get_sweeptime_averages')
@@ -44,6 +45,14 @@ class DummyVNA(Instrument):
         self.add_function('start_measurement')
         self.add_function('ready')
         self.add_function('post_measurement')
+        self.power = 0
+        
+    def do_get_power(self):
+        return  self.power
+    
+    def do_set_power(self,value):
+        print("Setting VNA power to ",value)
+        self.power = value
 
     def set_startfreq(self, startfreq):
         self.startfreq = startfreq

--- a/qkit/drivers/Keithley.py
+++ b/qkit/drivers/Keithley.py
@@ -94,46 +94,46 @@ class Keithley(Instrument):
         self._IV_units = {0: 'A', 1: 'V'}
         self._avg_types = ['moving average', 'repeat average', 'median']
         # dict of defaults values: defaults[<sweep_mode>][<channel>][<parameter>][<value>]
-        self._defaults = {0: [{'measurement_mode': 0,  # bias channel
-                               'bias_mode':  1,
-                               'sense_mode': 1,
-                               'bias_range': -1,
-                               'sense_range': -1,
-                               'bias_delay': 15e-6,
-                               'sense_delay': 15e-6,
-                               'sense_nplc': 1,
-                               'sense_average': 1,
-                               'sense_autozero': 0},
-                              {'measurement_mode': 0,  # sense channel
-                               'bias_mode': 0,
-                               'sense_mode': 1,
-                               'bias_range': -1,
-                               'sense_range': -1,
-                               'bias_delay': 15e-6,
-                               'sense_delay': 15e-6,
-                               'sense_nplc': 1,
-                               'sense_average': 1,
-                               'sense_autozero': 0}],
-                          1: [{'measurement_mode': 1,
-                               'bias_mode': 0,
-                               'sense_mode': 1,
-                               'bias_range': -1,
-                               'sense_range': -1,
-                               'bias_delay': 15e-6,
-                               'sense_delay': 15e-6,
-                               'sense_nplc': 1,
-                               'sense_average': 1,
-                               'sense_autozero': 0}],
-                          2: [{'measurement_mode': 1,
-                               'bias_mode': 1,
-                               'sense_mode': 0,
-                               'bias_range': -1,
-                               'sense_range': -1,
-                               'bias_delay': 15e-6,
-                               'sense_delay': 15e-6,
-                               'sense_nplc': 1,
-                               'sense_average': 1,
-                               'sense_autozero': 0}]}
+        self._defaults = {0: [{self.set_measurement_mode: 0,  # bias channel
+                               self.set_bias_mode:  1,
+                               self.set_sense_mode: 1,
+                               self.set_bias_range: -1,
+                               self.set_sense_range: -1,
+                               self.set_bias_delay: 15e-6,
+                               self.set_sense_delay: 15e-6,
+                               self.set_sense_nplc: 1,
+                               self.set_sense_average: 1,
+                               self.set_sense_autozero: 0},
+                              {self.set_measurement_mode: 0,  # sense channel
+                               self.set_bias_mode: 0,
+                               self.set_sense_mode: 1,
+                               self.set_bias_range: -1,
+                               self.set_sense_range: -1,
+                               self.set_bias_delay: 15e-6,
+                               self.set_sense_delay: 15e-6,
+                               self.set_sense_nplc: 1,
+                               self.set_sense_average: 1,
+                               self.set_sense_autozero: 0}],
+                          1: [{self.set_measurement_mode: 1,
+                               self.set_bias_mode: 0,
+                               self.set_sense_mode: 1,
+                               self.set_bias_range: -1,
+                               self.set_sense_range: -1,
+                               self.set_bias_delay: 15e-6,
+                               self.set_sense_delay: 15e-6,
+                               self.set_sense_nplc: 1,
+                               self.set_sense_average: 1,
+                               self.set_sense_autozero: 0}],
+                          2: [{self.set_measurement_mode: 1,
+                               self.set_bias_mode: 1,
+                               self.set_sense_mode: 0,
+                               self.set_bias_range: -1,
+                               self.set_sense_range: -1,
+                               self.set_bias_delay: 15e-6,
+                               self.set_sense_delay: 15e-6,
+                               self.set_sense_nplc: 1,
+                               self.set_sense_average: 1,
+                               self.set_sense_autozero: 0}]}
         self._default_str = 'default parameters'
         self.__set_defaults_docstring()
         # error messages
@@ -1276,6 +1276,7 @@ class Keithley(Instrument):
             step = -step
         for val in np.arange(start, stop, step)+step:
             self.set_bias_value(val, channel=channel)
+            print('{:f}{:s}'.format(val, self._IV_units[self.get_bias_mode()]), end='\r')
             time.sleep(step_time)
     
     def ramp_voltage(self, stop, step, step_time=0.1, channel=1):
@@ -1708,8 +1709,8 @@ class Keithley(Instrument):
             self.set_sweep_mode(sweep_mode)
         # set values
         for i, channel in enumerate(self._sweep_channels):
-            for key_parameter, val_parameter in self._defaults[self._sweep_mode][i].items():
-                eval('self.set_{:s}({!s}, channel={:d})'.format(key_parameter, val_parameter, channel))
+            for func, param in self._defaults[self._sweep_mode][i].items():
+                func(param, channel=channel)
         return
     
     def __set_defaults_docstring(self):
@@ -1917,42 +1918,40 @@ class Keithley(Instrument):
         parlist: dict
             Parameter names as keys, corresponding channels of interest as values.
         """
-        parlist = {'measurement_mode': [1, 2],
-                   'bias_mode': [1, 2],
-                   'sense_mode': [1, 2],
-                   'bias_range': [1, 2],
-                   'sense_range': [1, 2],
-                   'bias_delay': [1, 2],
-                   'sense_delay': [1, 2],
-                   'sense_average': [1, 2],
-                   'bias_value': [1, 2],
-                   'plc': [None],
-                   'sense_nplc': [1, 2],
-                   'sense_autozero': [1, 2],
-                   'status': [1, 2]}
+        parlist = {'measurement_mode': {'channels': [1, 2]},
+                   'bias_mode': {'channels': [1, 2]},
+                   'sense_mode': {'channels': [1, 2]},
+                   'bias_range': {'channels': [1, 2]},
+                   'sense_range': {'channels': [1, 2]},
+                   'bias_delay': {'channels': [1, 2]},
+                   'sense_delay': {'channels': [1, 2]},
+                   'sense_average': {'channels': [1, 2]},
+                   'bias_value': {'channels': [1, 2]},
+                   'plc': {'channels': [None]},
+                   'sense_nplc': {'channels': [1, 2]},
+                   'sense_autozero': {'channels': [1, 2]},
+                   'status': {'channels': [1, 2]}}
         return parlist
-    
+
     def get(self, param, **kwargs):
         """
         Gets the current parameter <param> by evaluation 'get_'+<param> and corresponding channel if needed
         In combination with <self.get_parameters> above.
-        
+
         Parameters
         ----------
         param: str
             Parameter of interest.
         channels: array_likes
-            Number of channels of interest. Must be in {1, 2} for channel specific parameters or None for channel independant (global) parameters.
-        
+            Number of channels of interest. Must be in {1, 2} for channel specific parameters or None for channel independent (global) parameters.
+
         Returns
         -------
         parlist: dict
             Parameter names as keys, values of corresponding channels as values.
         """
-        channels = kwargs.get('channels')
+        channels = kwargs.get('channels').get('channels')
         if channels == [None]:
-            return tuple(eval('map(lambda channel, self=self: self.get_{:s}(), [None])'.format(param)))
-            #return eval('self.get_{:s}()'.format(param))
+            return getattr(self, 'get_{!s}'.format(param))()
         else:
-            return tuple(eval('map(lambda channel, self=self: self.get_{:s}(channel=channel), [{:s}])'.format(param, ', '.join(map(str, channels)))))
-            #return tuple([eval('self.get_{:s}(channel={!s})'.format(param, channel)) for channel in channels])
+            return tuple([getattr(self, 'get_{!s}'.format(param))(channel=channel) for channel in channels])

--- a/qkit/drivers/Keysight_B2900.py
+++ b/qkit/drivers/Keysight_B2900.py
@@ -1591,6 +1591,7 @@ class Keysight_B2900(Instrument):
             step = -step
         for val in np.arange(start, stop, step) + step:
             self.set_bias_value(val, channel=channel)
+            print('{:f}{:s}'.format(val, self._IV_units[self.get_bias_mode()]), end='\r')
             time.sleep(step_time)
 
     def ramp_voltage(self, stop, step, step_time=0.1, channel=1):

--- a/qkit/drivers/Keysight_B2900.py
+++ b/qkit/drivers/Keysight_B2900.py
@@ -2482,19 +2482,19 @@ class Keysight_B2900(Instrument):
         parlist: dict
             Parameter names as keys, corresponding channels of interest as values.
         """
-        parlist = {'measurement_mode': range(1, self._channels + 1),
-                   'bias_mode': range(1, self._channels + 1),
-                   'sense_mode': range(1, self._channels + 1),
-                   'bias_range': range(1, self._channels + 1),
-                   'sense_range': range(1, self._channels + 1),
-                   'bias_trigger': range(1, self._channels + 1),
-                   'sense_trigger': range(1, self._channels + 1),
-                   'bias_delay': range(1, self._channels + 1),
-                   'sense_delay': range(1, self._channels + 1),
-                   'bias_value': range(1, self._channels + 1),
-                   'plc': [None],
-                   'sense_nplc': range(1, self._channels + 1),
-                   'status': range(1, self._channels + 1),
+        parlist = {'measurement_mode': {'channels': range(1, self._channels + 1)},
+                   'bias_mode': {'channels': range(1, self._channels + 1)},
+                   'sense_mode': {'channels': range(1, self._channels + 1)},
+                   'bias_range': {'channels': range(1, self._channels + 1)},
+                   'sense_range': {'channels': range(1, self._channels + 1)},
+                   'bias_trigger': {'channels': range(1, self._channels + 1)},
+                   'sense_trigger': {'channels': range(1, self._channels + 1)},
+                   'bias_delay': {'channels': range(1, self._channels + 1)},
+                   'sense_delay': {'channels': range(1, self._channels + 1)},
+                   'bias_value': {'channels': range(1, self._channels + 1)},
+                   'plc': {'channels': [None]},
+                   'sense_nplc': {'channels': range(1, self._channels + 1)},
+                   'status': {'channels': range(1, self._channels + 1)},
                    }
         return parlist
 
@@ -2515,7 +2515,7 @@ class Keysight_B2900(Instrument):
         parlist: dict
             Parameter names as keys, values of corresponding channels as values.
         """
-        channels = kwargs.get('channels')
+        channels = kwargs.get('channels').get('channels')
         if channels == [None]:
             return getattr(self, 'get_{!s}'.format(param))()
         else:

--- a/qkit/drivers/Keysight_E8267D.py
+++ b/qkit/drivers/Keysight_E8267D.py
@@ -64,9 +64,13 @@ class Keysight_E8267D(Instrument):
             self.reset()
         else:
             self.get_all()
-            
-        print('this is a copy of the Agilent E8257D driver, thourough testing of this driver in combination with the Keysight E8267D has NOT been done! proceed with caution!')
-        print('The max. output power and the frequency range depend on the order option of the Keysight E8267D! ')
+        
+        if self._visainstrument.query("*IDN?").split(",")[1].strip() == 'N5173B':
+            self.set_parameter_bounds("power",-20,19)
+            self.set_parameter_bounds("frequency",9e3,20e9)
+        else:
+            print('this is a copy of the Agilent E8257D driver, thourough testing of this driver in combination with the Keysight E8267D has NOT been done! proceed with caution!')
+            print('The max. output power and the frequency range depend on the order option of the Keysight E8267D! ')
     def reset(self):
         '''
         Resets the instrument to default values

--- a/qkit/drivers/Keysight_N5173B.py
+++ b/qkit/drivers/Keysight_N5173B.py
@@ -47,7 +47,7 @@ class Keysight_N5173B(Instrument):
 
         # Implement parameters
         self.add_parameter('power',
-            flags=Instrument.FLAG_GETSET, units='dBm', minval=-20, maxval=19, offset=True, type=float)
+            flags=Instrument.FLAG_GETSET, units='dBm', minval=-135, maxval=30, offset=True, type=float)
         #self.add_parameter('phase',
         #    flags=Instrument.FLAG_GETSET, units='rad', minval=-numpy.pi, maxval=numpy.pi, type=types.FloatType)
         self.add_parameter('frequency',

--- a/qkit/drivers/Keysight_N5173B.py
+++ b/qkit/drivers/Keysight_N5173B.py
@@ -47,10 +47,7 @@ class Keysight_N5173B(Instrument):
 
         # Implement parameters
         self.add_parameter('power',
-            flags=Instrument.FLAG_GETSET, units='dBm', minval=-50, maxval=30, type=float)
-        self.add_parameter('external_attenuation',
-            flags=Instrument.FLAG_GETSET, units='dB', minval=0, type=float)
-        self.ext_att = 0
+            flags=Instrument.FLAG_GETSET, units='dBm', minval=-20, maxval=19, offset=True, type=float)
         #self.add_parameter('phase',
         #    flags=Instrument.FLAG_GETSET, units='rad', minval=-numpy.pi, maxval=numpy.pi, type=types.FloatType)
         self.add_parameter('frequency',
@@ -110,7 +107,7 @@ class Keysight_N5173B(Instrument):
             ampl (float) : power in dBm
         '''
         logging.debug(__name__ + ' : get power')
-        return float(self._visainstrument.query('POW:AMPL?')) - self.ext_att
+        return float(self._visainstrument.query('POW:AMPL?'))
 
     def do_set_power(self, amp):
         '''
@@ -122,32 +119,8 @@ class Keysight_N5173B(Instrument):
         Output:
             None
         '''
-        logging.debug(__name__ + ' : set power to %f' % (amp + self.ext_att))
-        self._visainstrument.write('POW:AMPL %s' % (amp + self.ext_att))
-    
-    def do_set_external_attenuation(self, att=0):
-        '''
-        Sets an eventual external attenuation, that is later subtracted from power values.
-
-        Input:
-            att (float) : attenuation in dB (Default is 0)
-
-        Output:
-            None
-        '''
-        self.ext_att = att
-    
-    def do_get_external_attenuation(self):
-        '''
-        Gets an eventual external attenuation, that is subtracted from power values.
-
-        Input:
-            None
-
-        Output:
-            att (float) : attenuation in dB
-        '''
-        return self.ext_att
+        logging.debug(__name__ + ' : set power to %f' % amp)
+        self._visainstrument.write('POW:AMPL %s' % amp)
     
     #def do_get_phase(self):
     #    '''

--- a/qkit/drivers/Keysight_VNA_E5080B.py
+++ b/qkit/drivers/Keysight_VNA_E5080B.py
@@ -82,27 +82,27 @@ class Keysight_VNA_E5080B(Instrument):
                     
         self.add_parameter('centerfreq', type=float,
             flags=Instrument.FLAG_GETSET,
-            minval=0, maxval=14e9,
+            minval=0, maxval=20e9,
             units='Hz', tags=['sweep'])
 
         self.add_parameter('cwfreq', type=float,
             flags=Instrument.FLAG_GETSET,
-            minval=0, maxval=14e9,
+            minval=0, maxval=20e9,
             units='Hz', tags=['sweep'])
             
         self.add_parameter('startfreq', type=float,
             flags=Instrument.FLAG_GETSET,
-            minval=0, maxval=14e9,
+            minval=0, maxval=20e9,
             units='Hz', tags=['sweep'])            
             
         self.add_parameter('stopfreq', type=float,
             flags=Instrument.FLAG_GETSET,
-            minval=0, maxval=14e9,
+            minval=0, maxval=20e9,
             units='Hz', tags=['sweep'])                        
             
         self.add_parameter('span', type=float,
             flags=Instrument.FLAG_GETSET,
-            minval=0, maxval=14e9,
+            minval=0, maxval=20e9,
             units='Hz', tags=['sweep'])        
             
         self.add_parameter('power', type=float,

--- a/qkit/drivers/Keysight_VNA_E5080B.py
+++ b/qkit/drivers/Keysight_VNA_E5080B.py
@@ -107,7 +107,7 @@ class Keysight_VNA_E5080B(Instrument):
             
         self.add_parameter('power', type=float,
             flags=Instrument.FLAG_GETSET,
-            minval=-100, maxval=20,
+            minval=-100, maxval=20, offset=True,
             units='dBm', tags=['sweep'])
 
         self.add_parameter('startpower', type=float,

--- a/qkit/drivers/Yokogawa.py
+++ b/qkit/drivers/Yokogawa.py
@@ -90,50 +90,50 @@ class Yokogawa(Instrument):
         self._IV_modes = {0: 'curr', 1: 'volt'}
         self._IV_units = {0: 'A', 1: 'V'}
         # dict of defaults values: defaults[<sweep_mode>][<channel>][<parameter>][<value>]
-        self._defaults = {0: [{'measurement_mode': 0,
-                               'bias_mode': 1,
-                               'sense_mode': 1,
-                               'bias_range': -1,
-                               'sense_range': -1,
-                               'bias_delay': 200e-6,
-                               'sense_delay': 15e-6,
-                               'sense_nplc': 1,
-                               'sense_average': 1,
-                               'sense_autozero': 0},
-                              {'measurement_mode': 0,
-                               'bias_mode': 0,
-                               'sense_mode': 1,
-                               'bias_range': -1,
-                               'sense_range': -1,
-                               'bias_delay': 200e-6,
-                               'sense_delay': 15e-6,
-                               'sense_nplc': 1,
-                               'sense_average': 1,
-                               'sense_autozero': 0}],
-                          1: [{'measurement_mode': 1,
-                               'bias_mode': 0,
-                               'sense_mode': 1,
-                               'bias_trigger': '''str('sens')''',
-                               'sense_trigger': '''str('sour')''',
-                               'bias_range': -1,
-                               'sense_range': -1,
-                               'bias_delay': 200e-6,
-                               'sense_delay': 15e-6,
-                               'sense_nplc': 1,
-                               'sense_average': 1,
-                               'sense_autozero': 0}],
-                          2: [{'measurement_mode': 1,
-                               'bias_mode': 1,
-                               'sense_mode': 0,
-                               'bias_trigger': '''str('sens')''',
-                               'sense_trigger': '''str('sour')''',
-                               'bias_range': -1,
-                               'sense_range': -1,
-                               'bias_delay': 200e-6,
-                               'sense_delay': 15e-6,
-                               'sense_nplc': 1,
-                         'sense_average': 1,
-                         'sense_autozero': 0}]}
+        self._defaults = {0: [{self.set_measurement_mode: 0,
+                               self.set_bias_mode: 1,
+                               self.set_sense_mode: 1,
+                               self.set_bias_range: -1,
+                               self.set_sense_range: -1,
+                               self.set_bias_delay: 200e-6,
+                               self.set_sense_delay: 15e-6,
+                               self.set_sense_nplc: 1,
+                               self.set_sense_average: 1,
+                               self.set_sense_autozero: 0},
+                              {self.set_measurement_mode: 0,
+                               self.set_bias_mode: 0,
+                               self.set_sense_mode: 1,
+                               self.set_bias_range: -1,
+                               self.set_sense_range: -1,
+                               self.set_bias_delay: 200e-6,
+                               self.set_sense_delay: 15e-6,
+                               self.set_sense_nplc: 1,
+                               self.set_sense_average: 1,
+                               self.set_sense_autozero: 0}],
+                          1: [{self.set_measurement_mode: 1,
+                               self.set_bias_mode: 0,
+                               self.set_sense_mode: 1,
+                               self.set_bias_trigger: '''str('sens')''',
+                               self.set_sense_trigger: '''str('sour')''',
+                               self.set_bias_range: -1,
+                               self.set_sense_range: -1,
+                               self.set_bias_delay: 200e-6,
+                               self.set_sense_delay: 15e-6,
+                               self.set_sense_nplc: 1,
+                               self.set_sense_average: 1,
+                               self.set_sense_autozero: 0}],
+                          2: [{self.set_measurement_mode: 1,
+                               self.set_bias_mode: 1,
+                               self.set_sense_mode: 0,
+                               self.set_bias_trigger: '''str('sens')''',
+                               self.set_sense_trigger: '''str('sour')''',
+                               self.set_bias_range: -1,
+                               self.set_sense_range: -1,
+                               self.set_bias_delay: 200e-6,
+                               self.set_sense_delay: 15e-6,
+                               self.set_sense_nplc: 1,
+                               self.set_sense_average: 1,
+                               self.set_sense_autozero: 0}]}
         self._default_str = 'default parameters'
         self.__set_defaults_docstring()
         # condition code registers
@@ -1230,6 +1230,7 @@ class Yokogawa(Instrument):
             step = -step
         for val in np.arange(start, stop, step)+step:
             self.set_bias_value(val, channel=channel)
+            print('{:f}{:s}'.format(val, self._IV_units[self.get_bias_mode()]), end='\r')
             time.sleep(step_time)
         return
     
@@ -1968,8 +1969,8 @@ class Yokogawa(Instrument):
             self.set_sweep_mode(sweep_mode)
         # set values
         for i, channel in enumerate(self._sweep_channels):
-            for key_parameter, val_parameter in self._defaults[self._sweep_mode][i].items():
-                eval('self.set_{:s}({!s}, channel={:d})'.format(key_parameter, val_parameter, channel))
+            for func, param in self._defaults[self._sweep_mode][i].items():
+                func(param, channel=channel)
         return
     
     def __set_defaults_docstring(self):
@@ -2155,21 +2156,21 @@ class Yokogawa(Instrument):
             Parameter names as keys, corresponding channels of interest as values.
         """
         parlist = {'measurement_mode': [1, 2],
-                   'sync': [None],
-                   'bias_mode': [1, 2],
-                   'sense_mode': [1, 2],
-                   'bias_range': [1, 2],
-                   'sense_range': [1, 2],
-                   'bias_trigger': [1, 2],
-                   'sense_trigger': [1, 2],
-                   'bias_delay': [1, 2],
-                   'sense_delay': [1, 2],
-                   'sense_average': [1, 2],
-                   'bias_value': [1, 2],
-                   'plc': [None],
-                   'sense_nplc': [1, 2],
-                   'sense_autozero': [1, 2],
-                   'status': [1, 2]}
+                   'sync': {'channels': [None]},
+                   'bias_mode': {'channels': [1, 2]},
+                   'sense_mode': {'channels': [1, 2]},
+                   'bias_range': {'channels': [1, 2]},
+                   'sense_range': {'channels': [1, 2]},
+                   'bias_trigger': {'channels': [1, 2]},
+                   'sense_trigger': {'channels': [1, 2]},
+                   'bias_delay': {'channels': [1, 2]},
+                   'sense_delay': {'channels': [1, 2]},
+                   'sense_average': {'channels': [1, 2]},
+                   'bias_value': {'channels': [1, 2]},
+                   'plc': {'channels': [None]},
+                   'sense_nplc': {'channels': [1, 2]},
+                   'sense_autozero': {'channels': [1, 2]},
+                   'status': {'channels': [1, 2]}}
         return parlist
     
     def get(self, param, **kwargs):
@@ -2189,11 +2190,9 @@ class Yokogawa(Instrument):
         parlist: dict
             Parameter names as keys, values of corresponding channels as values.
         """
-        channels = kwargs.get('channels')
+        channels = kwargs.get('channels').get('channels')
         if channels == [None]:
-            return tuple(eval('map(lambda channel, self=self: self.get_{:s}(), [None])'.format(param)))
-            #return eval('self.get_{:s}()'.format(param))
+            return getattr(self, 'get_{!s}'.format(param))()
         else:
-            return tuple(eval('map(lambda channel, self=self: self.get_{:s}(channel=channel), [{:s}])'.format(param, ', '.join(map(str, channels)))))
-            #return tuple([eval('self.get_{:s}(channel={!s})'.format(param, channel)) for channel in channels])
+            return tuple([getattr(self, 'get_{!s}'.format(param))(channel=channel) for channel in channels])
     

--- a/qkit/measure/write_additional_files.py
+++ b/qkit/measure/write_additional_files.py
@@ -34,6 +34,8 @@ def get_instrument_settings(path):
         param_dict = {}
         for (param, popts) in _dict_to_ordered_tuples(ins.get_parameters()):
             param_dict.update({param:ins.get(param, query=False, channels=popts)})
+            if popts.get('offset',False):
+                param_dict.update({param+"_offset": ins._offsets[param]})
         instr_dict.update({ins_name:param_dict})
     with open(fn+'.set','w+') as filehandler:
         json.dump(obj=instr_dict, fp=filehandler, cls=QkitJSONEncoder, indent = 4, sort_keys=True)


### PR DESCRIPTION
In Instrument base we added an option for parameter offsets, that can be activated in the driver and accessed by set_<parameter>_offset. This is very useful for e.g. microwave powers when adding external attenuation. This branch was tested for several weeks and works without any problems.