### PR TITLE
Adds idempotent switch setter function.

### DIFF
--- a/qkit/drivers/switch_client.py
+++ b/qkit/drivers/switch_client.py
@@ -74,3 +74,16 @@ class switch_client(Instrument):
     def get_position(self,switch):
         self.socket.send_string("get/%i" % switch)
         return self.socket.recv_string()
+    
+    def is_at_position(self, switch, port):
+        self.socket.send_string("get/%i/%i" % (switch, port))
+        response = self.socket.recv_string() # This is a string of either "1" or "0", as per server code
+        return bool(int(response)) # convert string ("1"|"0") to in (1|0) to bool (True|False)
+    
+    def ensure_switch_at(self, switch, port):
+        """
+        Ensures that the switch is at the specified position.
+        Idempotent.
+        """
+        if not self.is_at_position(switch, port):
+            self.switch_to(switch, port)

--- a/qkit/drivers/switch_client.py
+++ b/qkit/drivers/switch_client.py
@@ -35,6 +35,8 @@ class switch_client(Instrument):
         self.add_function('enable')
         self.add_function('disable')
         self.add_function('switch_to')
+        self.add_function('is_at_position')
+        self.add_function('ensure_switch_at')
     
     def close(self):
         print("closing zmq socket")


### PR DESCRIPTION
When executing notebooks, caution is warranted, because setting the microwave switch position will heat up the cryostat. This introduces unwanted disturbances and slows down measurement progress.

## Changes
This pull request introduces two new functions:
- A wrapper of `get/<switch>/<position>` called `is_at_position`, returning True if the switch is at the given position
- An idempotent setter `ensure_at_position`, which ensures the microwave switch to be at the given position, but checking first, if any action is required.

## Discussion Questions
- Name of the functions