### PR TITLE
Base implementation of user path extension [RFC]

### DIFF
--- a/src/qkit/storage/hdf_DateTimeGenerator.py
+++ b/src/qkit/storage/hdf_DateTimeGenerator.py
@@ -64,12 +64,19 @@ class DateTimeGenerator(object):
             filename += '_' + str(name)
         self.returndict['_filename'] = filename + '.h5'
         '''New filename with datadir/run_id/user/uuid_name/uuid_name.h5'''
+
+        path_components = [
+            qkit.cfg.get('run_id', 'NO_RUN').strip().replace(" ", "_").upper(),
+            qkit.cfg.get('user', 'John_Doe').strip().replace(" ", "_")
+        ]
+
+        path_extension = qkit.cfg.get('path_extension')
+        if path_extension is not None and path_extension:
+            path_components.append(str(path_extension))
         
-        self.returndict['_relfolder'] = os.path.join(
-                qkit.cfg.get('run_id', 'NO_RUN').strip().replace(" ", "_").upper(),
-                qkit.cfg.get('user', 'John_Doe').strip().replace(" ", "_"),
-                filename
-        )
+        path_components.append(filename)
+        
+        self.returndict['_relfolder'] = os.path.join(*path_components)
 
 
 def encode_uuid(value):

--- a/tests/DTG_test.py
+++ b/tests/DTG_test.py
@@ -1,0 +1,15 @@
+import pytest
+from qkit.storage.hdf_DateTimeGenerator import DateTimeGenerator
+import qkit
+import re
+
+def test_DateTimeGenerator_no_extension():
+    dtg = DateTimeGenerator()
+    returndict = dtg.new_filename("test_file.h5")
+    assert re.match("NO_RUN/John_Doe/......_test_file\\.h5", returndict['_relfolder']) 
+
+def test_DateTimeGenerator_with_extension():
+    qkit.cfg['path_extension'] = 'extension'
+    dtg = DateTimeGenerator()
+    returndict = dtg.new_filename("test_file.h5")
+    assert re.match("NO_RUN/John_Doe/extension/......_test_file\\.h5", returndict['_relfolder']) 


### PR DESCRIPTION
# Current State
We are performing a lot of measurements, and it is often convenient to store them grouped by sample in a folder.
There is a hack to do so by changing the user's name:
```python
old_user = qkit.cfg['user']
qkit.cfg['user'] = old_user + r"\Sample\SubSample\MeasurementType\"
```
This works, but is cumbersome.

# Implementation Possibilities
## Per Measurement
When a measurement is started, the information could be pulled from the sample object. This, however is highly measurement specific and is not available at the point where the file name is generated (in `hdf_DateTimeGenerator.py`).

## Global Configuration (With provided implementation)
Less nice, but simpler to implement and test. A new configuration option would be available, called `path_extension` (preliminary). If set to a non-empty string, then the path is extended in `hdf_DateTimeGenerator.py`.

Usage would look like this:
```python
qkit.cfg['path_extension'] = r"Sample\SubSample\MeasurementType"
```

This allows the user to set the sample at the beginning of the notebook. This has two disadvantages:
- The user may forget to update this setting (but this is the case anyway)
- The information may differ from what is set in the Sample object. This is a bit more annoying, but happens already anyway.

The provided implementation includes `pytest` tests to verify that the implementation is equivalent to the old behaviour if `path_extension` is not set.

### Possible Extension: Natively Supported Hirarchy
If an array of string were allowed, then
```python
qkit.cfg['path_extension'] = ["Sample", "SubSample", "MeasurementType"]
```
colud become possible, removing problems with `\` and escape sequences.

### Possible Extension: Self-Resetting Configuration as a Safety Measure
`qkit.cfg['path_extension'] ` could be reset after each measurement to enforce the user sets it before each measurement. This would relax the second disadvantage mentioned above.

## Request for Comment
This is a change in the core module of qkit, which is why I'd like to ask for comments. I see the following questions:
1. Something like this is done in a hacky way already. Should we standardize this?
2. Should we enforce the hacky way is no longer possible?
3. Is an implementation in this way ok?
4. Is the name `path_extension` clear enough?
5. What form of documentation is needed?