### PR TITLE
Implementing QViewKit URL Handling

### DIFF
--- a/src/qkit/gui/qviewkit/main.py
+++ b/src/qkit/gui/qviewkit/main.py
@@ -146,6 +146,7 @@ def main(argv=sys.argv):
 
 
     parser.add_argument('-f','--file',     type=str, help='hdf filename to open')
+    parser.add_argument('-u','--url', type=str, help='url handler for qviewkit:UUID scheme. Derives file location from fid.')
     parser.add_argument('-ds','--datasets', type=str, help='(optional) datasets opened by default')
 
     parser.add_argument('-rt','--refresh_time', type=float, help='(optional) refresh time')
@@ -154,6 +155,19 @@ def main(argv=sys.argv):
     parser.add_argument('-qinfo','--qkit_info',default=False,action='store_true', help='(optional) if set, listen to qkit infos')
     args=parser.parse_args()
     data.args = args
+
+    # Check UUID lookup
+    if data.args.url: # A URL is set.
+        # Extract the UUID from the URI.
+        import re
+        url_regex = re.compile(r'qviewkit://([A-Z0-9]{6})')
+        match = url_regex.match(data.args.url)
+        uuid = match.group(1)
+
+        # Find the file
+        import qkit
+        qkit.start()
+        data.args.file = qkit.fid.get(uuid)
 
     # create Qt application
     if in_pyqt5:

--- a/src/qkit/gui/qviewkit/main.py
+++ b/src/qkit/gui/qviewkit/main.py
@@ -146,28 +146,14 @@ def main(argv=sys.argv):
 
 
     parser.add_argument('-f','--file',     type=str, help='hdf filename to open')
-    parser.add_argument('-u','--url', type=str, help='url handler for qviewkit:UUID scheme. Derives file location from fid.')
     parser.add_argument('-ds','--datasets', type=str, help='(optional) datasets opened by default')
 
     parser.add_argument('-rt','--refresh_time', type=float, help='(optional) refresh time')
     parser.add_argument('-sp','--save_plot',  default=False,action='store_true', help='(optional) save default plots')
     parser.add_argument('-live','--live_plot',default=False,action='store_true', help='(optional) if set, plots are reloaded')
     parser.add_argument('-qinfo','--qkit_info',default=False,action='store_true', help='(optional) if set, listen to qkit infos')
-    args=parser.parse_args()
+    args=parser.parse_args(args=argv[1:])
     data.args = args
-
-    # Check UUID lookup
-    if data.args.url: # A URL is set.
-        # Extract the UUID from the URI.
-        import re
-        url_regex = re.compile(r'qviewkit://([A-Z0-9]{6})')
-        match = url_regex.match(data.args.url)
-        uuid = match.group(1)
-
-        # Find the file
-        import qkit
-        qkit.start()
-        data.args.file = qkit.fid.get(uuid)
 
     # create Qt application
     if in_pyqt5:


### PR DESCRIPTION
# Premise
Recently, automatic documentation creation has been implemented as an [Add-On to QKit](https://github.com/qkitgroup/dokuwiki-autodoc). While this is already helpful, accessing the measurement file itself quickly could make the documentation even more useful.

The user usually has all their measurement on their machine already, and each measurement has an UUID, independent of where the measurement is located. A look up mechanism already exists.

# Proposed Change
This change implements a new command line option in `qviewkit`, `-u` or `--url`, which accepts a URL of the forma `qviewkit://UUIDAB` and opens the specified UUID.

This allows users to create a scheme handler (operating system dependent) to allow them to click on a link in their documentation to directly open qviekit with the measurement.

## Further Changes
The scheme `qviewkit` should be enabled in DokuWiki.

# Questions
- [ ] ~This change loads qkit to query the File Info Database when qviewkit is started and `-u` is set. Is this acceptable?~