### PR TITLE
Remote File Index Creation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,11 +33,12 @@ dependencies = [
 
 [project.scripts]
 qviewkit = "qkit.gui.qviewkit.main:main"
+qkit-fid-index = "qkit.entrypoint:index_directory"
 
 [project.optional-dependencies] # Here goes stuff like qiclib
 jupyter = [
     "jupyterlab>=3.6",
-    "jupyterlab-templates>=0.4",
+    "jupyterlab-templates>=0.5",
     "ipywidgets>=8.0"
 ]
 zurich-instruments = [

--- a/src/qkit/core/lib/file_service/file_info_database.py
+++ b/src/qkit/core/lib/file_service/file_info_database.py
@@ -110,7 +110,8 @@ class fid(file_system_service):
     history = property(lambda self: sorted(self.h5_db.keys()))
     
     def get_last(self):
-        return sorted(self.h5_db.keys())[-1]
+        with self.lock:
+            return sorted(self.h5_db.keys())[-1]
         
     def __getitem__(self, key):
         with self.lock:

--- a/src/qkit/entrypoint.py
+++ b/src/qkit/entrypoint.py
@@ -1,0 +1,31 @@
+import os
+from argparse import ArgumentParser, FileType
+import pathlib
+import logging
+
+def index_directory():
+    parser = ArgumentParser(description="Index a directory as a datadir and create a cache in place.")
+    parser.add_argument("--datadir", default=os.getcwd(), type=pathlib.Path)
+    args = parser.parse_args()
+
+    import qkit
+    # Setup directories.
+    qkit.cfg['datadir'] = args.datadir
+    qkit.cfg['logdir'] = os.path.join(args.datadir, "index-logs")
+    qkit.cfg['use_datadir_cache'] = False
+    qkit.cfg['file_log_level'] = 'INFO'
+    qkit.cfg['stdout_log_level'] = 'INFO'
+
+    # Check if it exists
+    if not os.path.exists(qkit.cfg['logdir']):
+        os.mkdir(qkit.cfg['logdir'])
+
+    assert os.path.isdir(qkit.cfg['logdir']), f"The assumed log directory {qkit.cfg['logdir']} is not a directory!"
+
+    # Configure a bare-bones qkit
+    qkit.cfg.preset_analyse()
+
+    # We need to start qkit, as it then loads the fid.
+    qkit.start(silent=True)
+    # This acquires the lock. If loading has finished, the lock is released and we continue.
+    logging.info(f"Indexed measurements up to {qkit.fid.get_last()}")


### PR DESCRIPTION
# Motivation
We store our measurements on a server, which makes backups and access to the files easier. However, indexing the files via SMB is slow. If the index were to be created periodically on the server, and the clients would access this index, all measurements would be available to everyone. This is a nice addition to the qviewkit-URL feature in [Dokuwiki-Autodoc](https://github.com/qkitgroup/dokuwiki-autodoc).

# Implementation
Besides some minor bug fixes, this pull request adds a secondary cache location in the data directory. If the config enables loading from this location, and this cache is loadable, then it will be used instead of a local cache.

Also, a new entry point (`qkit-fid-index`) is introduced to allow creation of the index from the command line. This could be used in the future for other setup tasks.

# Discussion Questions
- This change affects a core component of qkit (`qkit.fid`) and must be discussed.
- The command line utility `qkit-fid-index` redirects its log directory to be within the datadirectory, such that the cache files become available. This is a bit hacky, but the simplest solution. Is this sufficient?
- The locking mechanism from `qkit.fid.get_last` was missing. I think this is a bug. Were there use cases for this omission?