### PR TITLE
Fix Degradation in Avoided Level Crossing Fit

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,3 +70,5 @@ path = "src/qkit/__init__.py"
 allow-direct-references = true
 
 [tool.hatch.build]
+[tool.hatch.build.targets.sdist]
+exclude = ["data/*", "notebooks/*", "logs/*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,6 @@ qgrid = [
     "qgrid>=1.0"
 ]
 timedomain = [
-    "qiclib@https://git.scc.kit.edu/ipe-sdr-dev/software/qup_client.git>=0.0.2",
     "zerorpc>=0.6"
 ]
 

--- a/src/qkit/analysis/avoided_crossing_fit.py
+++ b/src/qkit/analysis/avoided_crossing_fit.py
@@ -324,9 +324,9 @@ class ACF():
         Here this is achieved by sorting according to the mean value of the y-datasets.
         """
         # Sort ydata by mean value.
-        indices = np.argsort([np.mean(i) for i in self.ydata])        
-        self.xdata = list(np.array(self.xdata, dtype=object)[indices])
-        self.ydata = list(np.array(self.ydata, dtype=object)[indices])
+        indices = np.argsort([np.mean(i) for i in self.ydata])
+        self.xdata = [self.xdata[i] for i in indices]
+        self.ydata = [self.ydata[i] for i in indices]    
         if min(np.gradient(indices)) < 0:
             print("\nChanging order of x- and y-data respectively...\n")
         return

--- a/src/qkit/analysis/avoided_crossing_fit.py
+++ b/src/qkit/analysis/avoided_crossing_fit.py
@@ -325,8 +325,8 @@ class ACF():
         """
         # Sort ydata by mean value.
         indices = np.argsort([np.mean(i) for i in self.ydata])        
-        self.xdata = list(np.array(self.xdata)[indices])
-        self.ydata = list(np.array(self.ydata)[indices])
+        self.xdata = list(np.array(self.xdata, dtype=object)[indices])
+        self.ydata = list(np.array(self.ydata, dtype=object)[indices])
         if min(np.gradient(indices)) < 0:
             print("\nChanging order of x- and y-data respectively...\n")
         return

--- a/src/qkit/gui/plot/plot.py
+++ b/src/qkit/gui/plot/plot.py
@@ -86,7 +86,7 @@ def plot(h5_filepath, datasets=[], refresh = 2, live = True, echo = False):
         return P
     else:
         os.putenv("HDF5_USE_FILE_LOCKING", 'FALSE')
-        return Popen(cmd, shell=False)
+        return Popen(cmd, shell=False, stdout=PIPE, text=True)
 
 
 # this is for saving plots


### PR DESCRIPTION
The sorting of the branches no longer works due to newer versions of numpy apparently explicitly requiring opting in to object arrays.
This is necessary, as these array may be inhomogeneous.

This fixes the degradation and allows usage of this analysis tool again.