### PR TITLE
Allow Access to QViewKit STDOUT

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,6 @@ qgrid = [
     "qgrid>=1.0"
 ]
 timedomain = [
-    "qiclib@https://git.scc.kit.edu/ipe-sdr-dev/software/qup_client.git>=0.0.2",
     "zerorpc>=0.6"
 ]
 

--- a/src/qkit/gui/plot/plot.py
+++ b/src/qkit/gui/plot/plot.py
@@ -86,7 +86,7 @@ def plot(h5_filepath, datasets=[], refresh = 2, live = True, echo = False):
         return P
     else:
         os.putenv("HDF5_USE_FILE_LOCKING", 'FALSE')
-        return Popen(cmd, shell=False)
+        return Popen(cmd, shell=False, stdout=PIPE, text=True)
 
 
 # this is for saving plots


### PR DESCRIPTION
This patch allows notebooks to capture the output of QViewKit, most notably the point picker.

The following snippet captures the output of the window:
```python
process = qkit.gui.plot.plot.plot(qkit.fid.get(UUID), live=False)
import time
while process.poll() is None:
    time.sleep(0.1)
child_output = process.stdout.readlines()
```

This can then be used to extract the saved points for further analysis, massively increasing user comfort.