### PR TITLE
Replaces removed `inspect.getargspec()` with modern `inspect.signature()`.

### DIFF
--- a/src/qkit/analysis/avoided_crossing_fit.py
+++ b/src/qkit/analysis/avoided_crossing_fit.py
@@ -165,7 +165,8 @@ class ACF():
         self._fct_par_names = []   # List of names of each functions parameters
         for fct in self.functions:
             if callable(fct):
-                par_names = inspect.getargspec(fct)[0]
+                sig = inspect.signature(fct)
+                par_names = list(sig.parameters.keys())
                 try:
                     # Remove self as fct argument if function is from acf class
                     par_names.remove("self")

--- a/src/qkit/core/instrument_tools.py
+++ b/src/qkit/core/instrument_tools.py
@@ -182,8 +182,8 @@ class Insttools(object):
         insclass = getattr(module, typename, None)
         if insclass is None:
             return None
-
-        return inspect.getargspec(insclass.__init__)
+        sig = inspect.signature(insclass.__init__)
+        return list(sig.parameters.keys())
 
     def get_instruments_by_type(self, typename):
         '''


### PR DESCRIPTION
In Python 3.11, `inspect.getargspec()` has been removed after being deprecated since version 3.0. This change replaces it with the more modern `inspect.signature()` method, which provides more granular access to method signatures, including type hints.

This shouldn't change anything, but make qkit more compatible with newer python version.