### PR TITLE
Fixes storage bug, fixes omitted warning in derivative

### DIFF
--- a/src/qkit/measure/transport/transport.py
+++ b/src/qkit/measure/transport/transport.py
@@ -293,7 +293,8 @@ class transport(object):
         # TODO: catch error, if len(dataset) < window_length in case of SavGol filter
         try:
             return self._numder_func(y, *self._numder_args, **self._numder_kwargs)/self._numder_func(x, *self._numder_args, **self._numder_kwargs)
-        except:
+        except Exception as e:
+            logging.warning("Can't calculate numerical derivative, possibly insufficient data points. %s", e)
             return np.zeros(len(y))*np.nan
     
     def set_x_dt(self, x_dt):

--- a/src/qkit/storage/hdf_file.py
+++ b/src/qkit/storage/hdf_file.py
@@ -272,12 +272,10 @@ class H5_file(object):
             if dim0 == 1:
                 fill[0] = 1
                 dim1 += 1
-            if reset:
-                ds[fill[0]-1,fill[1]-2] = data  # reset overwrites last data series
-            else:  # standard reset = False
-                ds.resize((dim0,dim1,len(data)))
-                fill[1] += 1
-                ds[fill[0]-1,fill[1]-1] = data
+            if not reset:  # standard reset = False
+                ds.resize((dim0,dim1,len(data))) # Update array size
+                fill[1] += 1 # Update write position
+            ds[fill[0]-1,fill[1]-1] = data # Our indices start with one.
             ds.attrs.modify("fill", fill)
 
         self.flush()


### PR DESCRIPTION
An off-by-one array indexing operation on write with reset caused data to be written into an incorrect position. This only gets noticed in transport measurements, because they do 3D-Measurements (2D Chip + 1D Sweep) with averaging in python (write with reset).

Also emits warning if derivatives can't be computed. 