### PR TITLE
Implements Bread Crumbs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
 
 [project.scripts]
 qviewkit = "qkit.gui.qviewkit.main:main"
+qkit-manual-breadcrumbs = "qkit.core.lib.file_service.breadcrumbs:manual_index"
 
 [project.optional-dependencies] # Here goes stuff like qiclib
 jupyter = [

--- a/src/qkit/core/lib/file_service/breadcrumbs.py
+++ b/src/qkit/core/lib/file_service/breadcrumbs.py
@@ -52,10 +52,9 @@ def read_breadcrumb(path: Path) -> dict[str, Path]:
     """
     Read a breadcrumb file.
     """
-    breadcrumb_path = derive_breadcrumb_filename()
-    breadcrumb_parent = breadcrumb_path.parent
+    breadcrumb_parent = path.parent
     uuid_map: dict[str, Path] = {}
-    with open(breadcrumb_path, mode="r") as f:
+    with open(path, mode="r") as f:
         for line in f.readlines():
             if line[6] == '=': # Valid format
                 uuid = line[:6]

--- a/src/qkit/core/lib/file_service/breadcrumbs.py
+++ b/src/qkit/core/lib/file_service/breadcrumbs.py
@@ -1,0 +1,85 @@
+"""
+This python file attempts to solve the problem of multiple machine beeing backed up to a different path, and the user still
+having to find .h5-Files using a UUID.
+
+While a human user can use intuition to find the file, even guided search fails to efficiently find UUID.h5 files. Here, a
+file based protocol is used to create hints for the search algorithm:
+
+When a machine has created its file info database, it is written to disk. It contains a mapping from the UUID to a path relative
+to the breadcrumb file. As a machine only sees its own files, and not the ones created by other machines, each machine must
+create a list of files it knows, at a location not colliding with the files of others.
+
+Here, we implement a file at `.{Node-UUID}.breadcrumb` derived fromt the MAC-Address.
+
+The file contents are untrusted. (Who knows where they come from.) They thus may not be pickled. The following format is used:
+UUID=rel_path\n
+
+The UUID is 6 symbols long. It is followed by an `=` symbol. The rest of the line is the relative path.
+"""
+
+from pathlib import Path
+import qkit
+import os
+import itertools
+
+FILE_END = ".breadcrumb"
+
+def derive_breadcrumb_filename() -> Path:
+    """
+    Derive a machine-unique breadcrumb file name in the data-directory.
+    """
+    import uuid
+    node = uuid.getnode()
+    filename = f".{node:x}{FILE_END}"
+    return Path(qkit.cfg['datadir']) / filename
+
+class BreadCrumbCreator():
+    """
+    Manages creating the initial bread crumb file and updating it after each measurement.
+    """
+
+    def __init__(self) -> None:
+        self._breadcrumb_path = derive_breadcrumb_filename()
+        if self._breadcrumb_path.exists():
+            os.remove(self._breadcrumb_path)
+        self._breadcrumb_file = open(self._breadcrumb_path, mode="w")
+
+    def append_entry(self, uuid: str, path: Path|str):
+        rel_path = Path(path).relative_to(self._breadcrumb_path.parent)
+        print(f"{uuid[:6]}={rel_path}", file=self._breadcrumb_file, flush=True) # Fails if uuid is not 6 digits
+
+def read_breadcrumb(path: Path) -> dict[str, Path]:
+    """
+    Read a breadcrumb file.
+    """
+    breadcrumb_path = derive_breadcrumb_filename()
+    breadcrumb_parent = breadcrumb_path.parent
+    uuid_map: dict[str, Path] = {}
+    with open(breadcrumb_path, mode="r") as f:
+        for line in f.readlines():
+            if line[6] == '=': # Valid format
+                uuid = line[:6]
+                rel_path = line[7:].strip()
+                uuid_map[uuid] = breadcrumb_parent / rel_path
+    return uuid_map
+
+def read_breadcrumbs(dir: Path) -> dict[str, Path]:
+    assert dir.is_dir(), "Directory must be a directory!"
+    breadcrumbs = [f for f in dir.iterdir() if f.is_file and f.name.endswith(FILE_END)]
+    return dict(itertools.chain.from_iterable(map(dict.items, map(read_breadcrumb, breadcrumbs))))
+
+def manual_index():
+    import os
+    import qkit
+
+    qkit.cfg['fid_scan_datadir'] = True
+    current_dir = os.getcwd()
+    print("Current Directory: ", current_dir)
+    if input("Index? (y/N)") == "y":
+        qkit.cfg['datadir'] = current_dir
+        import qkit.core.s_init.S16_available_modules
+        from qkit.core.lib.file_service.file_info_database import fid
+        fid = fid()
+
+if __name__ == "__main__":
+    manual_index()

--- a/src/qkit/core/lib/file_service/file_info_database_lib.py
+++ b/src/qkit/core/lib/file_service/file_info_database_lib.py
@@ -7,6 +7,7 @@ import time
 import json
 import numpy as np
 import qkit.storage.hdf_DateTimeGenerator as dtg
+from qkit.core.lib.file_service.breadcrumbs import BreadCrumbCreator
 import h5py
 
 try:
@@ -71,6 +72,8 @@ class file_system_service(UUID_base):
     
     _h5_mtime_db_path   = os.path.join(qkit.cfg['logdir'],"h5_mtime.db")
     _h5_info_cache_path = os.path.join(qkit.cfg['logdir'],"h5_info_cache.db")
+
+    _breadcrumb_creator = BreadCrumbCreator()
 
     lock = threading.Lock()
     
@@ -153,6 +156,7 @@ class file_system_service(UUID_base):
             # Note: All path entries with the same uuid are 
             # overwritten with the last found uuid indexed file
             self.h5_db[uuid] = fqpath
+            self._breadcrumb_creator.append_entry(uuid, fqpath)
 
             # we only care about the mtime of .h5 files 
             mtime = os.stat(fqpath).st_mtime
@@ -255,6 +259,7 @@ class file_system_service(UUID_base):
         basename = os.path.basename(h5_filename)[:-2]
         dirname = os.path.dirname(h5_filename)
         uuid = basename[:6]
+        self._breadcrumb_creator.append_entry(uuid, h5_filename)
         if h5_filename[-3:] != '.h5':
             logging.error("Tried to add '{:s}' to the qkit.fid database: Not a .h5 filename.".format(h5_filename))
         with self.lock:


### PR DESCRIPTION
# Problem Description
We have multiple machines being backed up to the same location, a NAS with very bad latency. This makes searching the archive slow. Also, the path the files are stored don't follow a trivial pattern, but relative paths remain valid.

# Solution
Each computer writes a machine-unique bread crumb file in its data root directory indicating for each UUID the relative path to that file. This way, when a program is looking for a UUID it only needs to find the bread crumb file, instead of searching the entire tree.

# Why?
This makes qviewkit://-URLs in dokuwiki-autodoc feasible and usable, without much overhead.