### PR TITLE
SHFQC driver implementation for frequency domain and time domain.

### DIFF
--- a/src/qkit/drivers/ZHInstSHFQC.py
+++ b/src/qkit/drivers/ZHInstSHFQC.py
@@ -1,6 +1,7 @@
 from qkit.core.instrument_base import Instrument
 from zhinst.toolkit import Session
 import numpy as np
+import math
 
 class ZHInstSHFQC(Instrument):
 
@@ -11,6 +12,7 @@ class ZHInstSHFQC(Instrument):
         self._sweeper = self._session.modules.create_shfqa_sweeper()
         self._sweeper.device(self._device)
         self._sweeper.use_sequencer = True
+        self._synth = [self._device.sgchannels[i].synthesizer() for i in range(6)]
 
         self.add_parameter('averages',
                            type=int,
@@ -82,6 +84,30 @@ class ZHInstSHFQC(Instrument):
                            maxval=1e3,
                            units='s',
                            tags=['sweep'])
+        
+        self.add_parameter('frequency',
+                           type=float,
+                           flags=Instrument.FLAG_GETSET,
+                           minval=0,
+                           maxval=9e9,
+                           units='Hz',
+                           tags=['mw'],
+                           channels=(1, 6))
+        
+        self.add_parameter('power',
+                           type=float,
+                           flags=Instrument.FLAG_GETSET,
+                           minval=-35,
+                           maxval=10,
+                           units='dBm',
+                           tags=['mw'],
+                           channels=(1, 6))
+        
+        self.add_parameter('status',
+                           type=bool,
+                           flags=Instrument.FLAG_GETSET,
+                           tags=['mw'],
+                           channels=(1, 6))
 
 
         self.add_function(self.set_sweep_range.__name__)
@@ -95,7 +121,7 @@ class ZHInstSHFQC(Instrument):
         self.add_function(self.avg_clear.__name__)
         self.add_function(self.get_all.__name__)
 
-    def get_all(self):
+    def get_all(self):  # Spectroscopy Compatibility
         for param in self._parameters:
             self.get(param)
 
@@ -107,31 +133,31 @@ class ZHInstSHFQC(Instrument):
         self._sweeper.sweep.start_freq(start_freq - center)
         self._sweeper.sweep.stop_freq(stop_freq - center)
 
-    def do_get_Average(self):
+    def do_get_Average(self):  # Spectroscopy Compatibility
         return True
 
-    def do_get_sweep_type(self):
+    def do_get_sweep_type(self):  # Spectroscopy Compatibility
         return 'LIN' # The device can do non-linear sweeps, but is not implemented here.
     
-    def do_get_startfreq(self):
+    def do_get_startfreq(self):  # Spectroscopy Compatibility
         return self._sweeper.sweep.start_freq() + self._sweeper.rf.center_freq()
     
-    def do_get_stopfreq(self):
+    def do_get_stopfreq(self):  # Spectroscopy Compatibility
         return self._sweeper.sweep.stop_freq() + self._sweeper.rf.center_freq()
     
-    def do_get_centerfreq(self):
+    def do_get_centerfreq(self):  # Spectroscopy Compatibility
         return (self.get_startfreq() + self.get_stopfreq()) / 2
     
-    def do_get_span(self):
+    def do_get_span(self):  # Spectroscopy Compatibility
         return self.get_stopfreq() - self.get_startfreq()
 
-    def do_set_nop(self, nop):
+    def do_set_nop(self, nop):  # Spectroscopy Compatibility
         self._sweeper.sweep.num_points(nop)
 
-    def do_get_nop(self):
+    def do_get_nop(self):  # Spectroscopy Compatibility
         return self._sweeper.sweep.num_points()
 
-    def set_sweep_amplitude(self, amp):
+    def set_sweep_amplitude(self, amp): 
         self._sweeper.sweep.oscillator_gain(amp)
     
     def set_sweep_integration(self, delay, int_time, wait_after):
@@ -141,14 +167,14 @@ class ZHInstSHFQC(Instrument):
         
         self._sweeper.average.mode('sequential')
 
-    def do_set_averages(self, averages):
+    def do_set_averages(self, averages):  # Spectroscopy Compatibility
         self._sweeper.average.num_average(averages)
 
-    def do_get_averages(self):
+    def do_get_averages(self):  # Spectroscopy Compatibility
         result = self._sweeper.average.num_average()
         return int(list(result.items())[0][1])
     
-    def avg_clear(self):
+    def avg_clear(self):  # Spectroscopy Compatibility
         pass # Per defaul, each measurement is cleared in SHFQC
 
     def set_rf_in_out(self, dB_in, dB_out):
@@ -166,13 +192,13 @@ class ZHInstSHFQC(Instrument):
     def start_measurement(self): # Spectrocopy Compatibility
         self._sweeper.run() # Blocking call
 
-    def do_get_sweeptime_averages(self):
+    def do_get_sweeptime_averages(self):  # Spectroscopy Compatibility
         return self._sweeper.predicted_cycle_time() * self.get_nop() * self.get_averages()
     
-    def do_get_sweeptime(self):
+    def do_get_sweeptime(self):  # Spectroscopy Compatibility
         return self._sweeper.predicted_cycle_time() * self.get_nop()
 
-    def get_freqpoints(self):
+    def get_freqpoints(self):  # Spectroscopy Compatibility
         freqs = np.linspace(self.get_startfreq(), self.get_stopfreq(), self.get_nop())
         return freqs
 
@@ -183,4 +209,43 @@ class ZHInstSHFQC(Instrument):
             return 10*np.log(np.abs(raw)**2 * 1000 / 50), np.angle(raw)
         elif format == 'RealImag':
             return np.real(raw), np.imag(raw)
+        
+    # MW Source Stuff
+    def do_set_frequency(self, frequency, channel):
+        synth = self._synth[channel - 1]
+        dev_synth = self._device.synthesizers[synth]
+        center = (frequency // 200e6) * 200e6
+        dev_synth.centerfreq(center)
+        
+        # Get difference to actually target frequency:
+        delta = frequency - dev_synth.centerfreq()
+        self._device.sgchannels[channel - 1].oscs[0].freq(delta)
+        self._device.sgchannels[channel - 1].awg.modulation.enable(1)
+        self._device.sgchannels[channel - 1].sines[0].i.enable(1)
+        self._device.sgchannels[channel - 1].sines[0].q.enable(1)
     
+    def do_get_frequency(self, channel):
+        synth = self._synth[channel - 1]
+        dev_synth = self._device.synthesizers[synth]
+        center = dev_synth.centerfreq()
+        offset = self._device.sgchannels[channel - 1].oscs[0].freq()
+        return center + offset
+    
+    def do_set_power(self, power, channel):
+        power_range = math.ceil(power / 5) * 5
+        self._device.sgchannels[channel-1].output.range(power_range)
+        delta = power - power_range
+        self._device.sgchannels[channel-1].awg.outputamplitude(10**(delta/10))
+    
+    def do_get_power(self, channel):
+        power_range = self._device.sgchannels[channel-1].output.range()
+        offset = self._device.sgchannels[channel-1].awg.outputamplitude()
+        return power_range + 10 * math.log10(offset)
+    
+    def do_get_status(self, channel):
+        return self._device.sgchannels[channel-1].output.on() == 1
+    
+    def do_set_status(self, enable, channel):
+        status = 1 if enable else 0
+        self._device.sgchannels[channel-1].output.on(status)
+        

--- a/src/qkit/drivers/ZHInstSHFQC.py
+++ b/src/qkit/drivers/ZHInstSHFQC.py
@@ -1,0 +1,53 @@
+from qkit.core.instrument_base import Instrument
+from zhinst.toolkit import Session
+
+class ZHInstSHFQC(Instrument):
+
+    def __init__(self, name, devID, server='localhost', **kwargs):
+        super().__init__(name, **kwargs)
+        self._session = Session(server)
+        self._device = self._session.connect_device(devID)
+        self._sweeper = self._session.modules.create_shfqa_sweeper()
+        self._sweeper.device(self._device)
+        self._sweeper.use_sequencer = True
+
+        self.add_function(self.set_sweep_range.__name__)
+        self.add_function(self.set_sweep_amplitude.__name__)
+        self.add_function(self.set_sweep_integration.__name__)
+        self.add_function(self.set_rf_in_out.__name__)
+        self.add_function(self.in_out_enable.__name__)
+        self.add_function(self.measure.__name__)
+
+
+    def set_sweep_range(self, start_freq, stop_freq, num_points):
+        center = min(int((start_freq + stop_freq) / 2 / 1e8) * 1e8, 8e9) # Can be set with 100Mhz precission
+        self._sweeper.rf.center_freq(center)
+        self._sweeper.sweep.start_freq(start_freq - center)
+        self._sweeper.sweep.stop_freq(stop_freq - center)
+        self._sweeper.sweep.num_points(num_points)
+
+    def set_sweep_amplitude(self, amp):
+        self._sweeper.sweep.oscillator_gain(amp)
+    
+    def set_sweep_integration(self, delay, int_time, wait_after, averages):
+        self._sweeper.average.integration_delay(delay)
+        self._sweeper.average.integration_time(int_time)
+        self._sweeper.sweep.wait_after_integration(wait_after)
+        self._sweeper.average.num_average(averages)
+        self._sweeper.average.mode('sequential')
+
+    def set_rf_in_out(self, dB_in, dB_out):
+        self._sweeper.rf.channel(0)
+        self._sweeper.rf.input_range(dB_in)
+        self._sweeper.rf.output_range(dB_out)
+    
+    def in_out_enable(self, enable: bool):
+        val = 1 if enable else 0
+        with self._device.set_transaction():
+            self._device.qachannels[0].input.on(val)
+            self._device.qachannels[0].output.on(val)
+            self._device.qachannels[0].output.rflfinterlock(1)
+
+    def measure(self):
+        result = self._sweeper.run()
+        return result

--- a/src/qkit/drivers/ZHInstSHFQC.py
+++ b/src/qkit/drivers/ZHInstSHFQC.py
@@ -216,6 +216,9 @@ class ZHInstSHFQC(Instrument):
         dev_synth = self._device.synthesizers[synth]
         center = (frequency // 200e6) * 200e6
         dev_synth.centerfreq(center)
+
+        # Ensure RF Path
+        self._device.sgchannels[channel - 1].output.rflfpath(1)
         
         # Get difference to actually target frequency:
         delta = frequency - dev_synth.centerfreq()
@@ -248,4 +251,4 @@ class ZHInstSHFQC(Instrument):
     def do_set_status(self, enable, channel):
         status = 1 if enable else 0
         self._device.sgchannels[channel-1].output.on(status)
-        
+

--- a/src/qkit/drivers/ZHInstSHFQC.py
+++ b/src/qkit/drivers/ZHInstSHFQC.py
@@ -1,6 +1,8 @@
 from qkit.core.instrument_base import Instrument
 from zhinst.toolkit import Session
-from laboneq.simple import Experiment, Session as LOQSession, DeviceSetup
+from laboneq.simple import Session as LOQSession, DeviceSetup
+from laboneq.dsl.result.results import Results
+from laboneq.dsl.experiment.experiment import Experiment
 import numpy as np
 import math
 
@@ -127,6 +129,7 @@ class ZHInstSHFQC(Instrument):
         self.add_function(self.get_all.__name__)
         self.add_function(self.compile_experiment.__name__)
         self.add_function(self.measure_td.__name__)
+        self.add_function(self.get_result_handles.__name__)
 
     def get_all(self):  # Spectroscopy Compatibility
         for param in self._parameters:
@@ -274,11 +277,19 @@ class ZHInstSHFQC(Instrument):
     # This will allow us to use all the work done by Zurich Instruments and get to TD Measurements quickly.
 
     def compile_experiment(self, experiment: Experiment, device_setup: DeviceSetup):
+        """
+        Install the experiment for the run.
+        """
         if self._laboneq_session is None:
             self._laboneq_session = LOQSession(device_setup=device_setup)
             self._laboneq_session.connect()
         self._laboneq_experiment = self._laboneq_session.compile(experiment)
 
-    def measure_td(self): # Start experiment, appears to be optional
+    def measure_td(self) -> Results:
+        """
+        Synchronously perform the measurement and return the data.
+
+        TODO: Allow for asynchronous measurements to get a status bar working and allow for interrupts?
+        """
         assert self._laboneq_session is not None
         return self._laboneq_session.run(self._laboneq_experiment)

--- a/src/qkit/measure/timedomain/measure_ZI_td.py
+++ b/src/qkit/measure/timedomain/measure_ZI_td.py
@@ -1,0 +1,62 @@
+from qkit.measure.measurement_base import MeasureBase
+from qkit.drivers.ZHInstSHFQC import ZHInstSHFQC
+from laboneq.data.experiment_results import AcquiredResults
+import numpy as np
+
+class MeasureTD(MeasureBase):
+
+    def __init__(self, shfqc: ZHInstSHFQC, sample=None):
+        super().__init__(sample)
+        self._shfqc = shfqc
+
+    def _prepare_measurement_devices(self):
+        # When prepared by user by compilation, everything is prepared.
+        pass
+
+    def _append(self, zi_result: AcquiredResults):
+        for (handle, result) in zi_result.items():
+            self._datasets[f"{handle}_real"].append(np.real(result.data))
+            self._datasets[f"{handle}_imag"].append(np.imag(result.data))
+            self._datasets[f"{handle}_amp"].append(np.abs(result.data))
+            self._datasets[f"{handle}_phase"].append(np.angle(result.data))
+
+    def _build_datafile_from_result(self, result: AcquiredResults, device_axis_unit: dict[str, str]):
+        """
+        Declare the datasets for saving.
+
+        We get the AcquiredResults object. It contains multiple handles (different readout categories.)
+        Each handle has an associated AcquiredResult containing:
+        - a complex valued ND array of the measurement result
+        - N associated axis names which were swept
+        - N arrays of values the swept value took.
+        """
+        coordinates = {} # Lookuptable for reuse
+        datasets = [] # Can be an array, less conversions.
+        for (handle, datum) in result.items(): # Iterate over measure categories
+            # Ensure all axes have been created
+            for axis_name, axis_values in zip(datum.axis_name, datum.axis):
+                assert axis_name is str, f"Unexpeced axis name type: {axis_name}"
+                if axis_name not in coordinates:
+                    coordinates[axis_name] = self.Coordinate(
+                        name=axis_name,
+                        unit=device_axis_unit[axis_name],
+                        values=axis_values
+                    )
+            
+            # Create dataset with existing axes
+            datasets.append(self.Data(f"{handle}_real", coords=[coordinates[axis_name] for axis_name in datum.axis_name]))
+            datasets.append(self.Data(f"{handle}_imag", coords=[coordinates[axis_name] for axis_name in datum.axis_name]))
+            datasets.append(self.Data(f"{handle}_amp", coords=[coordinates[axis_name] for axis_name in datum.axis_name]))
+            datasets.append(self.Data(f"{handle}_phase", coords=[coordinates[axis_name] for axis_name in datum.axis_name]))
+        self._prepare_measurement_file(data=datasets)
+
+    def measure_ND_ZI(self, device_axis_unit: dict[str, str]):
+        """
+        Take a 1D measurement with the ZHInst device. No external parameters are swept.
+
+        device_axis_unit: A string describing the unit of the ZI sweep axis.
+        """
+        result = self._shfqc.measure_td()
+        self._build_datafile_from_result(result.acquired_results, device_axis_unit)
+        self._append(result.acquired_results)
+        self._end_measurement()


### PR DESCRIPTION
This driver takes a 'we need to actually measure and only need to implement what we need for that'-approach.
It supports:
- Pseudo-VNA measurements
- Using the Signal Generators as Microwave Sources
- Using the LabOneQ-Library from Zurich Instruments

In case of the latter, qkit simply stores the results in appropriate hdf5-Files.

TODO(Optional):
- Support external parameter sweeps. (can be done using LabOneQ-API, which may mesh better with ZHInst devices).