### PR TITLE
Fixes text display in QViewKit

### DIFF
--- a/src/qkit/gui/qviewkit/PlotWindow_lib.py
+++ b/src/qkit/gui/qviewkit/PlotWindow_lib.py
@@ -771,7 +771,7 @@ def _display_string(ds):
     data = np.array(ds)
     txt = ""
     for d in data:
-        txt += d + '\n'
+        txt += d.decode('utf-8') + '\n'
     return txt
 
 


### PR DESCRIPTION
When displaying non-JSON text in Qviewkit, this fails due to a missing unicode decode.

This has gone unnoticed, because the text we store with measurements is always JSON.