### PR TITLE
Use SWMR mode for safe reading while writing.

### DIFF
--- a/src/qkit/gui/qviewkit/DatasetsWindow.py
+++ b/src/qkit/gui/qviewkit/DatasetsWindow.py
@@ -239,7 +239,7 @@ class DatasetsWindow(QMainWindow, Ui_MainWindow):
     def update_file(self):
         "update_file is regularly called when _something_ has to be updated. open-> do something->close"
         try:
-            self.h5file= h5py.File(str(self.DATA.DataFilePath),mode='r')
+            self.h5file= h5py.File(str(self.DATA.DataFilePath),mode='r', swmr=True)
             self.DATA.filename = self.h5file.filename.split(os.path.sep)[-1]
             self.populate_data_list()
             self.update_plots()

--- a/src/qkit/storage/hdf_file.py
+++ b/src/qkit/storage/hdf_file.py
@@ -52,7 +52,12 @@ class H5_file(object):
                 self.grp.attrs[k] = kw[k]
         
     def create_file(self,output_file, mode):
-        self.hf = h5py.File(output_file, mode,**file_kwargs )
+        kwargs = file_kwargs.copy()
+        if mode == 'r':
+            kwargs['swmr'] = True
+        self.hf = h5py.File(output_file, mode,**kwargs )
+        if mode in ('w', 'a'):
+            self.hf.swmr_mode = True
 
     def set_base_attributes(self):
         "stores some attributes and creates the default data group"

--- a/src/qkit/storage/hdf_file.py
+++ b/src/qkit/storage/hdf_file.py
@@ -15,7 +15,7 @@ from packaging.version import Version
 
 file_kwargs = dict()
 if Version(h5py.__version__) >= Version("3.5.0"): # new file locking
-    file_kwargs = dict(locking=False)
+    file_kwargs = dict(locking=False, libver='v110') # Minimum version required for SWMR
 elif Version(h5py.__version__) >= Version("3.0.0"): # intermediate
     logging.error("Qkit HDF file handling: In h5py between 3.0 and 3.5, there are problems with file locking handling. Please update to h5py==3.5.0")
 

--- a/tests/storage/swmr_test.py
+++ b/tests/storage/swmr_test.py
@@ -1,0 +1,59 @@
+import os
+
+import h5py
+import numpy as np
+import pytest
+
+from qkit.storage.hdf_file import H5_file
+
+
+def test_swmr_as_intended():
+    f = h5py.File("test.h5", "w", libver="latest")
+    f.swmr_mode = True
+    f.create_dataset("data", (10,), dtype="i", fillvalue=1)
+    # Not closing
+
+    f2 = h5py.File("test.h5", "r", swmr=True)
+    assert np.all(f2["data"][:] == 1)
+
+    f.close()
+    f2.close()
+    os.remove("test.h5")
+
+def test_with_qkit_hfd5():
+    f = H5_file(output_file='test.h5', mode='w')
+    f.create_dataset("data", (10,), dtype="i")
+    f['/entry/data0/data'][:] = 1
+    # Not closing
+
+    f2 = H5_file(output_file='test.h5', mode='r')
+    assert np.all(f2['/entry/data0/data'][:] == 1)
+    f.close_file()
+    f2.close_file()
+    os.remove('test.h5')
+
+def test_new_qkit_hdf5_no_swmr_read():
+    f = H5_file(output_file='test.h5', mode='w')
+    f.create_dataset("data", (10,), dtype="i")
+    f['/entry/data0/data'][:] = 1
+    # Not closing
+    
+    with pytest.raises(OSError):
+        h5py.File("test.h5", "r") # SWMR and file locking are incompatible
+
+    f2 = h5py.File("test.h5", "r", locking=False)
+    assert np.all(f2['/entry/data0/data'][:] == 1)
+    f.close_file()
+    f2.close()
+    os.remove('test.h5')
+
+def test_new_qkit_hdf5_after_closing():
+    f = H5_file(output_file='test.h5', mode='w')
+    f.create_dataset("data", (10,), dtype="i")
+    f['/entry/data0/data'][:] = 1
+    f.close_file()
+
+    f2 = h5py.File("test.h5", "r") # Corresponds to old qkit
+    assert np.all(f2['/entry/data0/data'][:] == 1)
+    f2.close()
+    os.remove('test.h5')


### PR DESCRIPTION
SWMR mode allows multiple readers while a single writer is writing.

This can be easily enabled in qviewkit.

We need to test if this is compatible with existing measurement classes, or if this needs to be a separate option.